### PR TITLE
feat: implement async message handling and comprehensive ipc integration tests

### DIFF
--- a/.kiro/specs/sentineld-core-monitoring/tasks.md
+++ b/.kiro/specs/sentineld-core-monitoring/tasks.md
@@ -17,7 +17,7 @@
   - Write unit tests for data model validation and serialization
   - _Requirements: 1.3, 4.1, 4.3_
 
-- [ ] 3. Migrate to interprocess crate for IPC protocol
+- [x] 3. Migrate to interprocess crate for IPC protocol
 
 - [x] 3.1 Define protobuf schema for IPC messages - [#35](https://github.com/EvilBit-Labs/SentinelD/issues/35)
 
@@ -51,7 +51,7 @@
   - Write unit tests for client connection scenarios and cross-platform compatibility
   - _Requirements: 3.1, 3.2_
 
-- [ ] 3.5 Comprehensive testing and validation for interprocess communication - [#38](https://github.com/EvilBit-Labs/SentinelD/issues/38)
+- [x] 3.5 Comprehensive testing and validation for interprocess communication - [#38](https://github.com/EvilBit-Labs/SentinelD/issues/38)
 
   - Create integration tests for `interprocess` transport behavior
   - Add cross-platform tests (Linux, macOS, Windows) for local socket functionality

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,12 +386,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
+name = "crc32c"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
- "cfg-if",
+ "rustc_version",
 ]
 
 [[package]]
@@ -1071,7 +1071,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "crc32fast",
+ "crc32c",
  "insta",
  "interprocess",
  "predicates",
@@ -1329,6 +1329,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
 name = "sentinel-lib"
 version = "0.1.0"
 dependencies = [
@@ -1384,7 +1399,7 @@ dependencies = [
  "blake3",
  "bytes",
  "chrono",
- "crc32fast",
+ "crc32c",
  "criterion",
  "futures",
  "futures-util",
@@ -1420,7 +1435,6 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "crc32fast",
  "futures",
  "insta",
  "interprocess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ chrono = { version = "0.4.42", features = ["serde"] }
 clap = { version = "4.5.48", features = ["derive"] }
 
 # CRC32 checksum
-crc32fast = "1.5.0"
+crc32c = "0.6.8"
 criterion = "0.7.0"
 futures = "0.3.31"
 futures-util = "0.3.31"

--- a/justfile
+++ b/justfile
@@ -66,11 +66,11 @@ setup:
 # Install development tools (extended setup)
 [windows]
 install-tools:
-    cargo binstall cargo-llvm-cov cargo-audit cargo-deny cargo-dist --locked
+    cargo binstall cargo-llvm-cov cargo-audit cargo-deny cargo-dist cargo-release cargo-cyclonedx cargo-auditable cargo-nextest --locked
 
 [unix]
 install-tools:
-    cargo binstall cargo-llvm-cov cargo-audit cargo-deny cargo-dist --locked
+    cargo binstall cargo-llvm-cov cargo-audit cargo-deny cargo-dist cargo-release cargo-cyclonedx cargo-auditable cargo-nextest --locked
 
 # Install mdBook and plugins for documentation
 [windows]
@@ -251,13 +251,13 @@ run-sentinelagent *args:
 # =============================================================================
 
 dist:
-    @cargo dist build
+    @dist build
 
 dist-check:
-    @cargo dist check
+    @dist check
 
 dist-plan:
-    @cargo dist plan
+    @dist plan
 
 install:
     @cargo install --path .

--- a/procmond/Cargo.toml
+++ b/procmond/Cargo.toml
@@ -32,10 +32,10 @@ bincode = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
-crc32fast = { workspace = true }
 
 # IPC communication
 interprocess = { workspace = true }
+crc32c = { workspace = true }
 
 # Protocol Buffers
 prost = { workspace = true }

--- a/procmond/src/ipc/mod.rs
+++ b/procmond/src/ipc/mod.rs
@@ -76,7 +76,7 @@ fn ensure_secure_directory(socket_path: &str) -> IpcResult<()> {
 
 /// Create an IPC server using the interprocess transport
 pub fn create_ipc_server(config: IpcConfig) -> IpcResult<sentinel_lib::ipc::InterprocessServer> {
-    use sentinel_lib::ipc::{IpcConfig as LibIpcConfig, TransportType};
+    use sentinel_lib::ipc::{IpcConfig as LibIpcConfig, PanicStrategy, TransportType};
 
     // Ensure the secure directory exists with proper permissions
     ensure_secure_directory(&config.path)?;
@@ -89,6 +89,7 @@ pub fn create_ipc_server(config: IpcConfig) -> IpcResult<sentinel_lib::ipc::Inte
         read_timeout_ms: config.message_timeout_secs * 1000,
         write_timeout_ms: config.message_timeout_secs * 1000,
         max_connections: config.max_connections,
+        panic_strategy: PanicStrategy::Abort, // Production configuration
     };
 
     Ok(sentinel_lib::ipc::InterprocessServer::new(lib_config))

--- a/procmond/src/ipc/mod.rs
+++ b/procmond/src/ipc/mod.rs
@@ -89,7 +89,6 @@ pub fn create_ipc_server(config: IpcConfig) -> IpcResult<sentinel_lib::ipc::Inte
         read_timeout_ms: config.message_timeout_secs * 1000,
         write_timeout_ms: config.message_timeout_secs * 1000,
         max_connections: config.max_connections,
-        crc32_variant: sentinel_lib::ipc::Crc32Variant::Ieee,
     };
 
     Ok(sentinel_lib::ipc::InterprocessServer::new(lib_config))

--- a/procmond/src/ipc/protocol.rs
+++ b/procmond/src/ipc/protocol.rs
@@ -49,9 +49,7 @@ impl MessageEnvelope {
         let checksum = if payload.is_empty() {
             0
         } else {
-            let mut hasher = crc32fast::Hasher::new();
-            hasher.update(&payload);
-            hasher.finalize()
+            crc32c::crc32c(&payload)
         };
         Self {
             sequence_number,
@@ -65,10 +63,7 @@ impl MessageEnvelope {
         if self.payload.is_empty() {
             self.checksum == 0
         } else {
-            let mut hasher = crc32fast::Hasher::new();
-            hasher.update(&self.payload);
-            let computed = hasher.finalize();
-            computed == self.checksum
+            crc32c::crc32c(&self.payload) == self.checksum
         }
     }
 }

--- a/sentinel-lib/Cargo.toml
+++ b/sentinel-lib/Cargo.toml
@@ -43,7 +43,7 @@ bytes = { workspace = true }
 
 # Date/time handling
 chrono = { workspace = true }
-crc32fast = { workspace = true }
+crc32c = { workspace = true }
 
 # Futures utilities
 futures = { workspace = true }

--- a/sentinel-lib/benches/ipc_communication.rs
+++ b/sentinel-lib/benches/ipc_communication.rs
@@ -164,6 +164,7 @@ fn bench_ipc_client_operations(c: &mut Criterion) {
                 read_timeout_ms: 5000,
                 write_timeout_ms: 5000,
                 transport: TransportType::Interprocess,
+                panic_strategy: sentinel_lib::ipc::PanicStrategy::Unwind,
             };
 
             let client = ResilientIpcClient::new(config);
@@ -180,6 +181,7 @@ fn bench_ipc_client_operations(c: &mut Criterion) {
             read_timeout_ms: 5000,
             write_timeout_ms: 5000,
             transport: TransportType::Interprocess,
+            panic_strategy: sentinel_lib::ipc::PanicStrategy::Unwind,
         };
 
         let client = ResilientIpcClient::new(config);
@@ -259,6 +261,7 @@ fn bench_concurrent_ipc_operations(c: &mut Criterion) {
                 read_timeout_ms: 5000,
                 write_timeout_ms: 5000,
                 transport: TransportType::Interprocess,
+                panic_strategy: sentinel_lib::ipc::PanicStrategy::Unwind,
             };
 
             // Create multiple clients concurrently using current runtime handle

--- a/sentinel-lib/benches/ipc_performance_comprehensive.rs
+++ b/sentinel-lib/benches/ipc_performance_comprehensive.rs
@@ -181,21 +181,7 @@ fn bench_crc32_performance(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(data_size as u64));
 
         group.bench_with_input(
-            BenchmarkId::new("crc32_ieee", size_name),
-            &data_size,
-            |b, &data_size| {
-                let test_data = vec![0_u8; data_size];
-                let _codec = IpcCodec::new(10 * 1024 * 1024);
-
-                b.iter(|| {
-                    let crc = crc32c::crc32c(&test_data);
-                    black_box(crc)
-                });
-            },
-        );
-
-        group.bench_with_input(
-            BenchmarkId::new("crc32_castagnoli", size_name),
+            BenchmarkId::new("crc32c", size_name),
             &data_size,
             |b, &data_size| {
                 let test_data = vec![0_u8; data_size];

--- a/sentinel-lib/benches/ipc_performance_comprehensive.rs
+++ b/sentinel-lib/benches/ipc_performance_comprehensive.rs
@@ -41,6 +41,7 @@ fn create_benchmark_config(test_name: &str) -> (IpcConfig, TempDir) {
         read_timeout_ms: 30000,
         write_timeout_ms: 30000,
         max_connections: 16,
+        panic_strategy: sentinel_lib::ipc::PanicStrategy::Unwind,
     };
 
     (config, temp_dir)

--- a/sentinel-lib/benches/ipc_performance_comprehensive.rs
+++ b/sentinel-lib/benches/ipc_performance_comprehensive.rs
@@ -1,0 +1,567 @@
+//! Comprehensive performance benchmarks for IPC communication
+//!
+//! This benchmark suite validates that there are no regressions in message
+//! throughput or latency for the interprocess transport implementation.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::str_to_string,
+    clippy::uninlined_format_args,
+    clippy::shadow_reuse,
+    clippy::as_conversions,
+    clippy::shadow_unrelated,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects
+)]
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use sentinel_lib::ipc::codec::{IpcCodec, IpcError};
+use sentinel_lib::ipc::interprocess_transport::{InterprocessClient, InterprocessServer};
+use sentinel_lib::ipc::{IpcConfig, ResilientIpcClient, TransportType};
+use sentinel_lib::proto::{DetectionResult, DetectionTask, ProcessRecord, TaskType};
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+use tokio::io::duplex;
+use tokio::runtime::Runtime;
+
+/// Create a test configuration for benchmarks
+fn create_benchmark_config(test_name: &str) -> (IpcConfig, TempDir) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let endpoint_path = create_benchmark_endpoint(&temp_dir, test_name);
+
+    let config = IpcConfig {
+        transport: TransportType::Interprocess,
+        endpoint_path,
+        max_frame_bytes: 10 * 1024 * 1024, // 10MB for large message tests
+        accept_timeout_ms: 5000,
+        read_timeout_ms: 30000,
+        write_timeout_ms: 30000,
+        max_connections: 16,
+    };
+
+    (config, temp_dir)
+}
+
+/// Create platform-specific benchmark endpoint
+fn create_benchmark_endpoint(temp_dir: &TempDir, test_name: &str) -> String {
+    #[cfg(unix)]
+    {
+        temp_dir
+            .path()
+            .join(format!("bench_{}.sock", test_name))
+            .to_string_lossy()
+            .to_string()
+    }
+    #[cfg(windows)]
+    {
+        let dir_name = temp_dir
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("bench");
+        format!(r"\\.\pipe\sentineld\bench-{}-{}", test_name, dir_name)
+    }
+}
+
+/// Create a test detection task
+fn create_benchmark_task(task_id: &str, metadata_size: usize) -> DetectionTask {
+    DetectionTask {
+        task_id: task_id.to_owned(),
+        task_type: TaskType::EnumerateProcesses.into(),
+        process_filter: None,
+        hash_check: None,
+        metadata: (metadata_size > 0).then(|| "x".repeat(metadata_size)),
+    }
+}
+
+/// Create a test process record
+fn create_benchmark_process_record(pid: u32) -> ProcessRecord {
+    ProcessRecord {
+        pid,
+        ppid: Some(pid.saturating_sub(1)),
+        name: format!("benchmark_process_{}", pid),
+        executable_path: Some(format!("/usr/bin/benchmark_{}", pid)),
+        command_line: vec![
+            format!("benchmark_{}", pid),
+            "--test".to_owned(),
+            format!("--pid={}", pid),
+        ],
+        start_time: Some(chrono::Utc::now().timestamp()),
+        cpu_usage: Some(25.5),
+        memory_usage: Some(1024 * 1024 * u64::from(pid)),
+        executable_hash: Some(format!("hash_{:08x}", pid)),
+        hash_algorithm: Some("sha256".to_owned()),
+        user_id: Some("1000".to_owned()),
+        accessible: true,
+        file_exists: true,
+        collection_time: chrono::Utc::now().timestamp_millis(),
+    }
+}
+
+/// Create a test detection result with specified number of processes
+fn create_benchmark_result(task_id: &str, num_processes: usize) -> DetectionResult {
+    let mut processes = Vec::with_capacity(num_processes);
+    for i in 0..num_processes {
+        processes.push(create_benchmark_process_record(i as u32));
+    }
+
+    DetectionResult {
+        task_id: task_id.to_owned(),
+        success: true,
+        error_message: None,
+        processes,
+        hash_result: None,
+    }
+}
+
+/// Benchmark codec serialization performance
+fn bench_codec_serialization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("codec_serialization");
+
+    // Test different message sizes
+    let message_sizes = vec![
+        ("small", 1),
+        ("medium", 100),
+        ("large", 1000),
+        ("xlarge", 10000),
+    ];
+
+    for (size_name, num_processes) in message_sizes {
+        group.throughput(Throughput::Elements(num_processes as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("serialize_detection_result", size_name),
+            &num_processes,
+            |b, &num_processes| {
+                let result = create_benchmark_result("benchmark", num_processes);
+
+                b.iter(|| {
+                    let serialized = prost::Message::encode_to_vec(&result);
+                    black_box(serialized.len())
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("deserialize_detection_result", size_name),
+            &num_processes,
+            |b, &num_processes| {
+                let result = create_benchmark_result("benchmark", num_processes);
+                let serialized = prost::Message::encode_to_vec(&result);
+
+                b.iter(|| {
+                    let deserialized: DetectionResult =
+                        prost::Message::decode(&serialized[..]).unwrap();
+                    black_box(deserialized.processes.len())
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark CRC32 calculation performance
+fn bench_crc32_performance(c: &mut Criterion) {
+    let mut group = c.benchmark_group("crc32_performance");
+
+    // Test different data sizes
+    let data_sizes = vec![
+        ("1kb", 1024),
+        ("10kb", 10 * 1024),
+        ("100kb", 100 * 1024),
+        ("1mb", 1024 * 1024),
+    ];
+
+    for (size_name, data_size) in data_sizes {
+        group.throughput(Throughput::Bytes(data_size as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("crc32_ieee", size_name),
+            &data_size,
+            |b, &data_size| {
+                let test_data = vec![0_u8; data_size];
+                let _codec = IpcCodec::new(10 * 1024 * 1024);
+
+                b.iter(|| {
+                    let crc = crc32c::crc32c(&test_data);
+                    black_box(crc)
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("crc32_castagnoli", size_name),
+            &data_size,
+            |b, &data_size| {
+                let test_data = vec![0_u8; data_size];
+                let _codec = IpcCodec::new(10 * 1024 * 1024);
+
+                b.iter(|| {
+                    let crc = crc32c::crc32c(&test_data);
+                    black_box(crc)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark message framing and unframing
+fn bench_message_framing_performance(c: &mut Criterion) {
+    let mut group = c.benchmark_group("message_framing");
+
+    let rt = Runtime::new().unwrap();
+
+    // Test different message sizes
+    let message_sizes = vec![("small", 100), ("medium", 10000), ("large", 1_000_000)];
+
+    for (size_name, num_processes) in message_sizes {
+        group.throughput(Throughput::Elements(num_processes as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("frame_message", size_name),
+            &num_processes,
+            |b, &num_processes| {
+                let result = create_benchmark_result("benchmark", num_processes);
+                let codec = IpcCodec::new(10 * 1024 * 1024);
+
+                b.iter(|| {
+                    rt.block_on(async {
+                        let (mut client, _server) = duplex(8192);
+                        let timeout = Duration::from_secs(1);
+
+                        let write_result = codec.write_message(&mut client, &result, timeout).await;
+                        black_box(write_result.is_ok())
+                    })
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("unframe_message", size_name),
+            &num_processes,
+            |b, &num_processes| {
+                let result = create_benchmark_result("benchmark", num_processes);
+                let mut codec = IpcCodec::new(10 * 1024 * 1024);
+
+                b.iter(|| {
+                    rt.block_on(async {
+                        let (mut client, mut server) = duplex(8192);
+                        let timeout = Duration::from_secs(1);
+
+                        // Write message
+                        let _write_result =
+                            codec.write_message(&mut client, &result, timeout).await;
+
+                        // Read message back
+                        let read_result: Result<DetectionResult, IpcError> =
+                            codec.read_message(&mut server, timeout).await;
+                        black_box(read_result.is_ok())
+                    })
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark end-to-end IPC communication
+fn bench_end_to_end_ipc(c: &mut Criterion) {
+    let mut group = c.benchmark_group("end_to_end_ipc");
+    group.sample_size(20); // Reduce sample size for slower end-to-end tests
+
+    let rt = Runtime::new().unwrap();
+
+    // Test different response sizes
+    let response_sizes = vec![("small", 1), ("medium", 100), ("large", 1000)];
+
+    for (size_name, num_processes) in response_sizes {
+        group.throughput(Throughput::Elements(num_processes as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("client_server_roundtrip", size_name),
+            &num_processes,
+            |b, &num_processes| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let (config, _temp_dir) =
+                            create_benchmark_config(&format!("roundtrip_{}", size_name));
+
+                        // Start server
+                        let mut server = InterprocessServer::new(config.clone());
+                        let response_size = num_processes;
+
+                        server.set_handler(move |task: DetectionTask| async move {
+                            Ok(create_benchmark_result(&task.task_id, response_size))
+                        });
+
+                        server.start().await.expect("Failed to start server");
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+
+                        // Send request
+                        let mut client = InterprocessClient::new(config.clone());
+                        let task = create_benchmark_task("benchmark", 0);
+
+                        let start_time = Instant::now();
+                        let result = client.send_task(task).await.expect("Request failed");
+                        let duration = start_time.elapsed();
+
+                        server.stop();
+
+                        black_box((result.success, duration))
+                    })
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark concurrent IPC operations
+fn bench_concurrent_ipc(c: &mut Criterion) {
+    let mut group = c.benchmark_group("concurrent_ipc");
+    group.sample_size(10); // Reduce sample size for concurrent tests
+
+    let rt = Runtime::new().unwrap();
+
+    // Test different concurrency levels
+    let concurrency_levels = vec![1, 2, 4, 8];
+
+    for concurrency in concurrency_levels {
+        group.bench_with_input(
+            BenchmarkId::new("concurrent_requests", concurrency),
+            &concurrency,
+            |b, &concurrency| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let (config, _temp_dir) =
+                            create_benchmark_config(&format!("concurrent_{}", concurrency));
+                        let request_counter = Arc::new(AtomicU32::new(0));
+                        let handler_counter = Arc::clone(&request_counter);
+
+                        // Start server
+                        let mut server = InterprocessServer::new(config.clone());
+
+                        server.set_handler(move |task: DetectionTask| {
+                            let counter = Arc::clone(&handler_counter);
+                            async move {
+                                let _request_num = counter.fetch_add(1, Ordering::SeqCst);
+                                Ok(create_benchmark_result(&task.task_id, 10))
+                            }
+                        });
+
+                        server.start().await.expect("Failed to start server");
+                        tokio::time::sleep(Duration::from_millis(200)).await;
+
+                        // Send concurrent requests
+                        let mut handles = vec![];
+                        let start_time = Instant::now();
+
+                        for i in 0..concurrency {
+                            let client_config = config.clone();
+                            let handle = tokio::spawn(async move {
+                                let mut client = InterprocessClient::new(client_config);
+                                let task = create_benchmark_task(&format!("concurrent_{}", i), 0);
+                                client.send_task(task).await
+                            });
+                            handles.push(handle);
+                        }
+
+                        // Wait for all requests to complete
+                        let mut successful_requests = 0;
+                        for handle in handles {
+                            if let Ok(Ok(_)) = handle.await {
+                                successful_requests += 1;
+                            }
+                        }
+
+                        let total_duration = start_time.elapsed();
+                        server.stop();
+
+                        black_box((successful_requests, total_duration))
+                    })
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark resilient client performance
+fn bench_resilient_client(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resilient_client");
+
+    let rt = Runtime::new().unwrap();
+
+    group.bench_function("client_creation", |b| {
+        b.iter(|| {
+            let (config, _temp_dir) = create_benchmark_config("client_creation");
+            let client = ResilientIpcClient::new(config);
+            black_box(client)
+        });
+    });
+
+    group.bench_function("client_stats_retrieval", |b| {
+        let (config, _temp_dir) = create_benchmark_config("client_stats");
+        let client = ResilientIpcClient::new(config);
+
+        b.iter(|| {
+            rt.block_on(async {
+                let stats = client.get_stats().await;
+                black_box(stats)
+            })
+        });
+    });
+
+    group.bench_function("connection_state_check", |b| {
+        let (config, _temp_dir) = create_benchmark_config("connection_state");
+        let client = ResilientIpcClient::new(config);
+
+        b.iter(|| {
+            rt.block_on(async {
+                let state = client.get_connection_state().await;
+                black_box(state)
+            })
+        });
+    });
+
+    group.finish();
+}
+
+/// Benchmark message throughput
+fn bench_message_throughput(c: &mut Criterion) {
+    let mut group = c.benchmark_group("message_throughput");
+
+    let rt = Runtime::new().unwrap();
+
+    // Test sustained throughput with different message sizes
+    let throughput_tests = vec![
+        ("small_burst", 100, 10),  // 100 small messages
+        ("medium_burst", 50, 100), // 50 medium messages
+        ("large_burst", 10, 1000), // 10 large messages
+    ];
+
+    for (test_name, num_messages, processes_per_message) in throughput_tests {
+        group.throughput(Throughput::Elements(
+            (num_messages * processes_per_message) as u64,
+        ));
+
+        group.bench_with_input(
+            BenchmarkId::new("sustained_throughput", test_name),
+            &(num_messages, processes_per_message),
+            |b, &(num_messages, processes_per_message)| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let (config, _temp_dir) =
+                            create_benchmark_config(&format!("throughput_{}", test_name));
+
+                        // Start server
+                        let mut server = InterprocessServer::new(config.clone());
+                        let response_size = processes_per_message;
+
+                        server.set_handler(move |task: DetectionTask| async move {
+                            Ok(create_benchmark_result(&task.task_id, response_size))
+                        });
+
+                        server.start().await.expect("Failed to start server");
+                        tokio::time::sleep(Duration::from_millis(200)).await;
+
+                        // Send burst of messages
+                        let mut client = InterprocessClient::new(config.clone());
+                        let start_time = Instant::now();
+
+                        for i in 0..num_messages {
+                            let task = create_benchmark_task(&format!("throughput_{}", i), 0);
+                            let _result = client.send_task(task).await.expect("Request failed");
+                        }
+
+                        let duration = start_time.elapsed();
+                        server.stop();
+
+                        black_box(duration)
+                    })
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark latency characteristics
+fn bench_latency_characteristics(c: &mut Criterion) {
+    let mut group = c.benchmark_group("latency_characteristics");
+    group.sample_size(50); // More samples for latency measurements
+
+    let rt = Runtime::new().unwrap();
+
+    // Test latency with different message sizes
+    let latency_tests = vec![
+        ("minimal", 0), // No processes
+        ("small", 1),   // 1 process
+        ("medium", 10), // 10 processes
+        ("large", 100), // 100 processes
+    ];
+
+    for (test_name, num_processes) in latency_tests {
+        group.bench_with_input(
+            BenchmarkId::new("request_latency", test_name),
+            &num_processes,
+            |b, &num_processes| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let (config, _temp_dir) =
+                            create_benchmark_config(&format!("latency_{}", test_name));
+
+                        // Start server
+                        let mut server = InterprocessServer::new(config.clone());
+                        let response_size = num_processes;
+
+                        server.set_handler(move |task: DetectionTask| async move {
+                            Ok(create_benchmark_result(&task.task_id, response_size))
+                        });
+
+                        server.start().await.expect("Failed to start server");
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+
+                        // Measure single request latency
+                        let mut client = InterprocessClient::new(config.clone());
+                        let task = create_benchmark_task("latency_test", 0);
+
+                        let start_time = Instant::now();
+                        let _result = client.send_task(task).await.expect("Request failed");
+                        let latency = start_time.elapsed();
+
+                        server.stop();
+
+                        black_box(latency)
+                    })
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_codec_serialization,
+    bench_crc32_performance,
+    bench_message_framing_performance,
+    bench_end_to_end_ipc,
+    bench_concurrent_ipc,
+    bench_resilient_client,
+    bench_message_throughput,
+    bench_latency_characteristics
+);
+criterion_main!(benches);

--- a/sentinel-lib/src/ipc/client.rs
+++ b/sentinel-lib/src/ipc/client.rs
@@ -126,7 +126,7 @@ pub struct ResilientIpcClient {
 impl ResilientIpcClient {
     /// Create a new resilient IPC client
     pub fn new(config: IpcConfig) -> Self {
-        let codec = IpcCodec::new(config.max_frame_bytes, config.crc32_variant.clone());
+        let codec = IpcCodec::new(config.max_frame_bytes);
 
         Self {
             config,
@@ -421,7 +421,6 @@ mod tests {
             read_timeout_ms: 5000,
             write_timeout_ms: 5000,
             max_connections: 4,
-            crc32_variant: crate::ipc::Crc32Variant::Ieee,
         };
 
         (config, temp_dir)

--- a/sentinel-lib/src/ipc/codec.rs
+++ b/sentinel-lib/src/ipc/codec.rs
@@ -43,6 +43,21 @@ pub enum IpcError {
 
     #[error("Invalid message length: {length}")]
     InvalidLength { length: u32 },
+
+    #[error("Server not found at {endpoint} - ensure procmond is running")]
+    ServerNotFound { endpoint: String },
+
+    #[error("Connection refused to {endpoint} - server may not be accepting connections")]
+    ConnectionRefused { endpoint: String },
+
+    #[error("Permission denied connecting to {endpoint} - check file permissions")]
+    PermissionDenied { endpoint: String },
+
+    #[error("Connection timeout to {endpoint} - server may be overloaded")]
+    ConnectionTimeout { endpoint: String },
+
+    #[error("Circuit breaker is open - too many recent failures")]
+    CircuitBreakerOpen,
 }
 
 /// Codec for encoding and decoding protobuf messages with CRC32C validation

--- a/sentinel-lib/src/ipc/interprocess_transport.rs
+++ b/sentinel-lib/src/ipc/interprocess_transport.rs
@@ -64,7 +64,7 @@ impl InterprocessServer {
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let config = IpcConfig::default();
-    /// let server = InterprocessServer::new(config)?;
+    /// let server = InterprocessServer::new(config);
     /// # Ok(())
     /// # }
     /// ```
@@ -109,7 +109,7 @@ impl InterprocessServer {
     /// use sentinel_lib::proto::{DetectionTask, DetectionResult};
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut server = InterprocessServer::new(IpcConfig::default())?;
+    /// let mut server = InterprocessServer::new(IpcConfig::default());
     ///
     /// server.set_handler(|task: DetectionTask| async move {
     ///     // Process the detection task
@@ -272,7 +272,7 @@ impl InterprocessServer {
         handler: MessageHandler,
         config: IpcConfig,
     ) -> IpcResult<()> {
-        let mut codec = IpcCodec::new(config.max_frame_bytes, config.crc32_variant.clone());
+        let mut codec = IpcCodec::new(config.max_frame_bytes);
         let read_timeout = Duration::from_millis(config.read_timeout_ms);
         let write_timeout = Duration::from_millis(config.write_timeout_ms);
 
@@ -356,7 +356,7 @@ pub struct InterprocessClient {
 impl InterprocessClient {
     /// Create a new interprocess client
     pub fn new(config: IpcConfig) -> Self {
-        let codec = IpcCodec::new(config.max_frame_bytes, config.crc32_variant.clone());
+        let codec = IpcCodec::new(config.max_frame_bytes);
         Self { config, codec }
     }
 

--- a/sentinel-lib/src/ipc/mod.rs
+++ b/sentinel-lib/src/ipc/mod.rs
@@ -30,8 +30,6 @@ pub struct IpcConfig {
     pub write_timeout_ms: u64,
     /// Maximum concurrent connections
     pub max_connections: usize,
-    /// CRC32 variant for integrity validation
-    pub crc32_variant: Crc32Variant,
 }
 
 impl Default for IpcConfig {
@@ -44,7 +42,6 @@ impl Default for IpcConfig {
             read_timeout_ms: 30000,       // 30 seconds
             write_timeout_ms: 10000,      // 10 seconds
             max_connections: 16,
-            crc32_variant: Crc32Variant::Ieee,
         }
     }
 }
@@ -55,16 +52,6 @@ impl Default for IpcConfig {
 pub enum TransportType {
     /// Use tokio native IPC transport (default)
     Interprocess,
-}
-
-/// CRC32 variant for integrity validation
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum Crc32Variant {
-    /// IEEE 802.3 CRC32 (default)
-    Ieee,
-    /// Castagnoli CRC32C
-    Castagnoli,
 }
 
 /// Get the default endpoint path based on the platform
@@ -89,7 +76,6 @@ mod tests {
         assert_eq!(config.transport, TransportType::Interprocess);
         assert_eq!(config.max_frame_bytes, 1024 * 1024);
         assert_eq!(config.max_connections, 16);
-        assert_eq!(config.crc32_variant, Crc32Variant::Ieee);
     }
 
     #[test]

--- a/sentinel-lib/src/ipc/mod.rs
+++ b/sentinel-lib/src/ipc/mod.rs
@@ -30,6 +30,8 @@ pub struct IpcConfig {
     pub write_timeout_ms: u64,
     /// Maximum concurrent connections
     pub max_connections: usize,
+    /// Panic strategy for production environments
+    pub panic_strategy: PanicStrategy,
 }
 
 impl Default for IpcConfig {
@@ -42,6 +44,7 @@ impl Default for IpcConfig {
             read_timeout_ms: 30000,       // 30 seconds
             write_timeout_ms: 10000,      // 10 seconds
             max_connections: 16,
+            panic_strategy: PanicStrategy::Unwind, // Default to unwind for development
         }
     }
 }
@@ -52,6 +55,33 @@ impl Default for IpcConfig {
 pub enum TransportType {
     /// Use tokio native IPC transport (default)
     Interprocess,
+}
+
+/// Panic strategy for production environments
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PanicStrategy {
+    /// Allow panics to unwind (default for development)
+    Unwind,
+    /// Abort on panic (recommended for production)
+    Abort,
+}
+
+impl IpcConfig {
+    /// Create a production-ready configuration with abort-on-panic strategy
+    pub fn production() -> Self {
+        Self {
+            panic_strategy: PanicStrategy::Abort,
+            ..Self::default()
+        }
+    }
+
+    /// Configure the panic strategy
+    #[must_use]
+    pub const fn with_panic_strategy(mut self, strategy: PanicStrategy) -> Self {
+        self.panic_strategy = strategy;
+        self
+    }
 }
 
 /// Get the default endpoint path based on the platform

--- a/sentinel-lib/tests/ipc_comprehensive_integration.rs
+++ b/sentinel-lib/tests/ipc_comprehensive_integration.rs
@@ -1,0 +1,701 @@
+//! Comprehensive integration tests for interprocess communication
+//!
+//! This test suite validates the complete IPC transport behavior including:
+//! - Cross-platform local socket functionality
+//! - Task distribution and result collection workflows
+//! - Error handling and recovery scenarios
+//! - Security validation for socket permissions and connection limits
+
+#![allow(
+    clippy::expect_used,
+    clippy::str_to_string,
+    clippy::as_conversions,
+    clippy::uninlined_format_args,
+    clippy::use_debug,
+    clippy::shadow_reuse,
+    clippy::shadow_unrelated,
+    clippy::single_match_else,
+    clippy::case_sensitive_file_extension_comparisons,
+    clippy::redundant_else
+)]
+
+use sentinel_lib::ipc::codec::IpcError;
+use sentinel_lib::ipc::interprocess_transport::{InterprocessClient, InterprocessServer};
+use sentinel_lib::ipc::{IpcConfig, TransportType};
+use sentinel_lib::proto::{DetectionResult, DetectionTask, ProcessRecord, TaskType};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+use tokio::sync::Barrier;
+use tokio::time::{sleep, timeout};
+
+/// Create a test configuration with unique endpoint
+fn create_test_config(test_name: &str) -> (IpcConfig, TempDir) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let endpoint_path = create_test_endpoint(&temp_dir, test_name);
+
+    let config = IpcConfig {
+        transport: TransportType::Interprocess,
+        endpoint_path,
+        max_frame_bytes: 1024 * 1024,
+        accept_timeout_ms: 2000,
+        read_timeout_ms: 10000,
+        write_timeout_ms: 10000,
+        max_connections: 8,
+    };
+
+    (config, temp_dir)
+}
+
+/// Create platform-specific test endpoint
+fn create_test_endpoint(temp_dir: &TempDir, test_name: &str) -> String {
+    #[cfg(unix)]
+    {
+        temp_dir
+            .path()
+            .join(format!("{}.sock", test_name))
+            .to_string_lossy()
+            .to_string()
+    }
+    #[cfg(windows)]
+    {
+        let dir_name = temp_dir
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("test");
+        format!(r"\\.\pipe\sentineld\{}-{}", test_name, dir_name)
+    }
+}
+
+/// Create a test detection task
+fn create_test_task(task_id: &str) -> DetectionTask {
+    DetectionTask {
+        task_id: task_id.to_owned(),
+        task_type: TaskType::EnumerateProcesses.into(),
+        process_filter: None,
+        hash_check: None,
+        metadata: Some("comprehensive integration test".to_owned()),
+    }
+}
+
+/// Create a test process record
+fn create_test_process_record(pid: u32) -> ProcessRecord {
+    ProcessRecord {
+        pid,
+        ppid: Some(1),
+        name: format!("test_process_{}", pid),
+        executable_path: Some(format!("/usr/bin/test_{}", pid)),
+        command_line: vec![
+            format!("test_{}", pid),
+            "--arg".to_owned(),
+            "value".to_owned(),
+        ],
+        start_time: Some(chrono::Utc::now().timestamp()),
+        cpu_usage: Some(25.5),
+        memory_usage: Some(1024 * 1024),
+        executable_hash: Some(format!("hash_{:08x}", pid)),
+        hash_algorithm: Some("sha256".to_owned()),
+        user_id: Some("1000".to_owned()),
+        accessible: true,
+        file_exists: true,
+        collection_time: chrono::Utc::now().timestamp_millis(),
+    }
+}
+
+/// Test cross-platform transport behavior
+#[tokio::test]
+async fn test_cross_platform_transport_behavior() {
+    let (config, _temp_dir) = create_test_config("cross_platform");
+
+    // Test server creation and startup
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(|task: DetectionTask| async move {
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: None,
+            processes: vec![create_test_process_record(1234)],
+            hash_result: None,
+        })
+    });
+
+    // Start server and verify it binds correctly
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Test client connection and communication
+    let mut client = InterprocessClient::new(config.clone());
+    let task = create_test_task("cross_platform_test");
+
+    let result = timeout(Duration::from_secs(10), client.send_task(task))
+        .await
+        .expect("Client request timed out")
+        .expect("Client request failed");
+
+    assert!(result.success);
+    assert_eq!(result.processes.len(), 1);
+    assert_eq!(result.processes.first().map(|p| p.pid), Some(1234));
+
+    // Verify platform-specific endpoint behavior
+    #[cfg(unix)]
+    {
+        // Unix socket should exist as file
+        assert!(std::path::Path::new(&config.endpoint_path).exists());
+
+        // Check socket permissions (should be 0600)
+        let metadata =
+            std::fs::metadata(&config.endpoint_path).expect("Failed to get socket metadata");
+        let permissions = metadata.permissions();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = permissions.mode();
+            // Socket should have owner read/write only (0600)
+            assert_eq!(mode & 0o777, 0o600, "Socket permissions should be 0600");
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        // Windows named pipe should be accessible
+        assert!(config.endpoint_path.starts_with(r"\\.\pipe\"));
+    }
+
+    server.stop();
+}
+
+/// Test task distribution and result collection workflows
+#[tokio::test]
+async fn test_task_distribution_workflows() {
+    let (config, _temp_dir) = create_test_config("task_distribution");
+    let task_counter = Arc::new(AtomicU32::new(0));
+    let handler_counter = Arc::clone(&task_counter);
+
+    // Start server with task counting handler
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(move |task: DetectionTask| {
+        let counter = Arc::clone(&handler_counter);
+        async move {
+            let task_num = counter.fetch_add(1, Ordering::SeqCst);
+
+            // Simulate different task types and processing times
+            let processes = match task.task_type {
+                x if x == TaskType::EnumerateProcesses as i32 => {
+                    vec![
+                        create_test_process_record(1000 + task_num),
+                        create_test_process_record(2000 + task_num),
+                    ]
+                }
+                x if x == TaskType::CheckProcessHash as i32 => {
+                    vec![create_test_process_record(3000 + task_num)]
+                }
+                _ => vec![],
+            };
+
+            // Add processing delay to simulate real work
+            sleep(Duration::from_millis(50)).await;
+
+            Ok(DetectionResult {
+                task_id: task.task_id,
+                success: true,
+                error_message: None,
+                processes,
+                hash_result: None,
+            })
+        }
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Test multiple task types
+    let mut client = InterprocessClient::new(config.clone());
+
+    // Test enumerate processes task
+    let enum_task = DetectionTask {
+        task_id: "enum_test".to_owned(),
+        task_type: TaskType::EnumerateProcesses.into(),
+        process_filter: None,
+        hash_check: None,
+        metadata: Some("enumerate test".to_owned()),
+    };
+
+    let enum_result = timeout(Duration::from_secs(10), client.send_task(enum_task))
+        .await
+        .expect("Enumerate task timed out")
+        .expect("Enumerate task failed");
+
+    assert!(enum_result.success);
+    assert_eq!(enum_result.processes.len(), 2);
+    assert_eq!(enum_result.task_id, "enum_test");
+
+    // Test hash check task
+    let hash_task = DetectionTask {
+        task_id: "hash_test".to_owned(),
+        task_type: TaskType::CheckProcessHash.into(),
+        process_filter: None,
+        hash_check: None,
+        metadata: Some("hash check test".to_owned()),
+    };
+
+    let hash_result = timeout(Duration::from_secs(10), client.send_task(hash_task))
+        .await
+        .expect("Hash task timed out")
+        .expect("Hash task failed");
+
+    assert!(hash_result.success);
+    assert_eq!(hash_result.processes.len(), 1);
+    assert_eq!(hash_result.task_id, "hash_test");
+
+    // Verify task counter
+    assert_eq!(task_counter.load(Ordering::SeqCst), 2);
+
+    server.stop();
+}
+
+/// Test concurrent task distribution
+#[tokio::test]
+async fn test_concurrent_task_distribution() {
+    let (config, _temp_dir) = create_test_config("concurrent_tasks");
+    let task_counter = Arc::new(AtomicU32::new(0));
+    let handler_counter = Arc::clone(&task_counter);
+
+    // Start server
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(move |task: DetectionTask| {
+        let counter = Arc::clone(&handler_counter);
+        async move {
+            let task_num = counter.fetch_add(1, Ordering::SeqCst);
+
+            // Simulate processing time
+            sleep(Duration::from_millis(100)).await;
+
+            Ok(DetectionResult {
+                task_id: task.task_id,
+                success: true,
+                error_message: None,
+                processes: vec![create_test_process_record(task_num)],
+                hash_result: None,
+            })
+        }
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Send multiple concurrent tasks
+    let num_tasks = 5;
+    let barrier = Arc::new(Barrier::new(num_tasks));
+    let mut handles = vec![];
+
+    for i in 0..num_tasks {
+        let client_config = config.clone();
+        let task_barrier = Arc::clone(&barrier);
+
+        let handle = tokio::spawn(async move {
+            // Wait for all tasks to be ready
+            task_barrier.wait().await;
+
+            let mut client = InterprocessClient::new(client_config);
+            let task = create_test_task(&format!("concurrent_task_{}", i));
+
+            let start_time = Instant::now();
+            let result = timeout(Duration::from_secs(15), client.send_task(task))
+                .await
+                .expect("Concurrent task timed out")
+                .expect("Concurrent task failed");
+            let duration = start_time.elapsed();
+
+            (i, result, duration)
+        });
+
+        handles.push(handle);
+    }
+
+    // Wait for all tasks to complete
+    let mut results = vec![];
+    for handle in handles {
+        let (task_id, result, duration) = handle.await.expect("Task handle failed");
+        results.push((task_id, result, duration));
+    }
+
+    // Verify all tasks completed successfully
+    assert_eq!(results.len(), num_tasks);
+    for (task_id, result, duration) in results {
+        assert!(result.success, "Task {} failed", task_id);
+        assert_eq!(result.task_id, format!("concurrent_task_{}", task_id));
+        assert!(!result.processes.is_empty());
+
+        // Verify reasonable processing time (should be concurrent, not sequential)
+        assert!(
+            duration < Duration::from_secs(5),
+            "Task {} took too long: {:?}",
+            task_id,
+            duration
+        );
+    }
+
+    // Verify all tasks were processed
+    assert_eq!(task_counter.load(Ordering::SeqCst), num_tasks as u32);
+
+    server.stop();
+}
+
+/// Test error handling and recovery scenarios
+#[tokio::test]
+async fn test_error_handling_and_recovery() {
+    let (config, _temp_dir) = create_test_config("error_handling");
+    let error_counter = Arc::new(AtomicU32::new(0));
+    let handler_counter = Arc::clone(&error_counter);
+
+    // Start server with error-prone handler
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(move |task: DetectionTask| {
+        let counter = Arc::clone(&handler_counter);
+        async move {
+            let error_count = counter.fetch_add(1, Ordering::SeqCst);
+
+            // Fail first few requests, then succeed
+            if error_count < 3 {
+                return Err(IpcError::Encode(format!(
+                    "Simulated error #{}",
+                    error_count + 1
+                )));
+            }
+
+            Ok(DetectionResult {
+                task_id: task.task_id,
+                success: true,
+                error_message: None,
+                processes: vec![create_test_process_record(1000)],
+                hash_result: None,
+            })
+        }
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Test error responses
+    let mut client = InterprocessClient::new(config.clone());
+
+    // First request should fail
+    let task1 = create_test_task("error_test_1");
+    let result1 = timeout(Duration::from_secs(10), client.send_task(task1))
+        .await
+        .expect("Error test 1 timed out")
+        .expect("Error test 1 failed to get response");
+
+    assert!(!result1.success);
+    assert!(result1.error_message.is_some());
+    assert!(
+        result1
+            .error_message
+            .as_ref()
+            .is_some_and(|msg| msg.contains("Simulated error #1"))
+    );
+
+    // Second request should also fail
+    let task2 = create_test_task("error_test_2");
+    let result2 = timeout(Duration::from_secs(10), client.send_task(task2))
+        .await
+        .expect("Error test 2 timed out")
+        .expect("Error test 2 failed to get response");
+
+    assert!(!result2.success);
+    assert!(result2.error_message.is_some());
+    assert!(
+        result2
+            .error_message
+            .as_ref()
+            .is_some_and(|msg| msg.contains("Simulated error #2"))
+    );
+
+    // Third request should also fail
+    let task3 = create_test_task("error_test_3");
+    let result3 = timeout(Duration::from_secs(10), client.send_task(task3))
+        .await
+        .expect("Error test 3 timed out")
+        .expect("Error test 3 failed to get response");
+
+    assert!(!result3.success);
+    assert!(result3.error_message.is_some());
+    assert!(
+        result3
+            .error_message
+            .as_ref()
+            .is_some_and(|msg| msg.contains("Simulated error #3"))
+    );
+
+    // Fourth request should succeed (recovery)
+    let task4 = create_test_task("recovery_test");
+    let result4 = timeout(Duration::from_secs(10), client.send_task(task4))
+        .await
+        .expect("Recovery test timed out")
+        .expect("Recovery test failed");
+
+    assert!(result4.success);
+    assert!(result4.error_message.is_none());
+    assert_eq!(result4.processes.len(), 1);
+
+    server.stop();
+}
+
+/// Test connection limits and security validation
+#[tokio::test]
+async fn test_connection_limits_and_security() {
+    let (mut config, _temp_dir) = create_test_config("connection_limits");
+
+    // Set a low connection limit for testing
+    config.max_connections = 2;
+
+    let connection_counter = Arc::new(AtomicU32::new(0));
+    let handler_counter = Arc::clone(&connection_counter);
+
+    // Start server with connection tracking
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(move |task: DetectionTask| {
+        let counter = Arc::clone(&handler_counter);
+        async move {
+            let conn_num = counter.fetch_add(1, Ordering::SeqCst);
+
+            // Hold connection open for a while to test limits
+            sleep(Duration::from_millis(500)).await;
+
+            Ok(DetectionResult {
+                task_id: task.task_id,
+                success: true,
+                error_message: None,
+                processes: vec![create_test_process_record(conn_num)],
+                hash_result: None,
+            })
+        }
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Test connection limit enforcement
+    let num_clients = 4; // More than the limit of 2
+    let mut handles = vec![];
+
+    for i in 0..num_clients {
+        let client_config = config.clone();
+
+        let handle = tokio::spawn(async move {
+            let mut client = InterprocessClient::new(client_config);
+            let task = create_test_task(&format!("limit_test_{}", i));
+
+            // Some connections may be rejected due to limits
+            timeout(Duration::from_secs(10), client.send_task(task)).await
+        });
+
+        handles.push(handle);
+    }
+
+    // Wait for all attempts to complete
+    let mut successful_connections = 0;
+    let mut failed_connections = 0;
+
+    for (i, handle) in handles.into_iter().enumerate() {
+        match handle.await {
+            Ok(Ok(Ok(result))) => {
+                assert!(result.success);
+                successful_connections += 1;
+            }
+            Ok(Ok(Err(_))) => {
+                // Connection failed (expected due to limits)
+                failed_connections += 1;
+            }
+            Ok(Err(_)) => {
+                // Timeout (also expected due to limits)
+                failed_connections += 1;
+            }
+            Err(e) => {
+                eprintln!("Task {} panicked: {}", i, e);
+                failed_connections += 1;
+            }
+        }
+    }
+
+    // Should have some successful connections but not all due to limits
+    assert!(successful_connections > 0, "No connections succeeded");
+    assert!(
+        successful_connections <= config.max_connections,
+        "Too many connections succeeded: {} > {}",
+        successful_connections,
+        config.max_connections
+    );
+
+    eprintln!(
+        "Connection limit test: {} successful, {} failed (limit: {})",
+        successful_connections, failed_connections, config.max_connections
+    );
+
+    server.stop();
+}
+
+/// Test server shutdown and cleanup
+#[tokio::test]
+async fn test_server_shutdown_and_cleanup() {
+    let (config, _temp_dir) = create_test_config("shutdown_cleanup");
+
+    // Start server
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(|task: DetectionTask| async move {
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: None,
+            processes: vec![],
+            hash_result: None,
+        })
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Verify server is running
+    let mut client = InterprocessClient::new(config.clone());
+    let task = create_test_task("shutdown_test");
+
+    let result = timeout(Duration::from_secs(5), client.send_task(task))
+        .await
+        .expect("Pre-shutdown test timed out")
+        .expect("Pre-shutdown test failed");
+
+    assert!(result.success);
+
+    // Stop server
+    server.stop();
+
+    // Give server time to clean up
+    sleep(Duration::from_millis(200)).await;
+
+    // Verify server is no longer accepting connections
+    let mut client2 = InterprocessClient::new(config.clone());
+    let task2 = create_test_task("post_shutdown_test");
+
+    let result2 = timeout(Duration::from_secs(2), client2.send_task(task2)).await;
+
+    // Should fail to connect or timeout
+    assert!(
+        result2.is_err() || result2.is_ok_and(|r| r.is_err()),
+        "Client should not be able to connect after server shutdown"
+    );
+
+    // Verify socket cleanup on Unix
+    #[cfg(unix)]
+    {
+        // Socket file should be removed
+        assert!(
+            !std::path::Path::new(&config.endpoint_path).exists(),
+            "Socket file should be cleaned up after server shutdown"
+        );
+    }
+}
+
+/// Test large message handling
+#[tokio::test]
+async fn test_large_message_handling() {
+    let (config, _temp_dir) = create_test_config("large_messages");
+
+    // Start server
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(|task: DetectionTask| async move {
+        // Create a large response with many process records
+        let mut processes = vec![];
+        for i in 0..1000 {
+            processes.push(create_test_process_record(i));
+        }
+
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: None,
+            processes,
+            hash_result: None,
+        })
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Send task and receive large response
+    let mut client = InterprocessClient::new(config.clone());
+    let task = create_test_task("large_message_test");
+
+    let result = timeout(Duration::from_secs(30), client.send_task(task))
+        .await
+        .expect("Large message test timed out")
+        .expect("Large message test failed");
+
+    assert!(result.success);
+    assert_eq!(result.processes.len(), 1000);
+
+    // Verify all process records are intact
+    for (i, process) in result.processes.iter().enumerate() {
+        assert_eq!(process.pid, i as u32);
+        assert_eq!(process.name, format!("test_process_{}", i));
+    }
+
+    server.stop();
+}
+
+/// Test timeout handling
+#[tokio::test]
+async fn test_timeout_handling() {
+    let (mut config, _temp_dir) = create_test_config("timeout_handling");
+
+    // Set short timeouts for testing
+    config.read_timeout_ms = 1000;
+    config.write_timeout_ms = 1000;
+
+    // Start server with slow handler
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(|task: DetectionTask| async move {
+        // Simulate slow processing that exceeds timeout
+        sleep(Duration::from_millis(2000)).await;
+
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: None,
+            processes: vec![],
+            hash_result: None,
+        })
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Send task that should timeout
+    let mut client = InterprocessClient::new(config.clone());
+    let task = create_test_task("timeout_test");
+
+    let result = timeout(Duration::from_secs(5), client.send_task(task)).await;
+
+    // Should timeout or receive error response
+    match result {
+        Ok(Ok(response)) => {
+            // If we get a response, it should indicate an error
+            assert!(!response.success || response.error_message.is_some());
+        }
+        Ok(Err(_)) | Err(_) => {
+            // Expected: IPC error due to timeout or outer timeout
+        }
+    }
+
+    server.stop();
+}

--- a/sentinel-lib/tests/ipc_cross_platform_tests.rs
+++ b/sentinel-lib/tests/ipc_cross_platform_tests.rs
@@ -1,0 +1,626 @@
+//! Cross-platform tests for IPC transport behavior
+//!
+//! This test suite validates platform-specific behavior and ensures
+//! consistent functionality across Linux, macOS, and Windows.
+
+#![allow(
+    clippy::expect_used,
+    clippy::str_to_string,
+    clippy::as_conversions,
+    clippy::uninlined_format_args,
+    clippy::use_debug,
+    clippy::shadow_reuse,
+    clippy::shadow_unrelated,
+    clippy::single_match_else,
+    clippy::case_sensitive_file_extension_comparisons,
+    clippy::redundant_else,
+    clippy::panic,
+    clippy::modulo_arithmetic
+)]
+
+use sentinel_lib::ipc::interprocess_transport::{InterprocessClient, InterprocessServer};
+use sentinel_lib::ipc::{IpcConfig, TransportType};
+use sentinel_lib::proto::{DetectionResult, DetectionTask, ProcessRecord, TaskType};
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::time::{sleep, timeout};
+
+/// Create a cross-platform test configuration
+fn create_cross_platform_config(test_name: &str) -> (IpcConfig, TempDir) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let endpoint_path = create_cross_platform_endpoint(&temp_dir, test_name);
+
+    let config = IpcConfig {
+        transport: TransportType::Interprocess,
+        endpoint_path,
+        max_frame_bytes: 1024 * 1024,
+        accept_timeout_ms: 3000,
+        read_timeout_ms: 10000,
+        write_timeout_ms: 10000,
+        max_connections: 8,
+    };
+
+    (config, temp_dir)
+}
+
+/// Create platform-specific endpoint path
+fn create_cross_platform_endpoint(temp_dir: &TempDir, test_name: &str) -> String {
+    #[cfg(unix)]
+    {
+        temp_dir
+            .path()
+            .join(format!("cross_platform_{}.sock", test_name))
+            .to_string_lossy()
+            .to_string()
+    }
+    #[cfg(windows)]
+    {
+        let dir_name = temp_dir
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("cross_platform");
+        format!(
+            r"\\.\pipe\sentineld\cross-platform-{}-{}",
+            test_name, dir_name
+        )
+    }
+}
+
+/// Create a test detection task
+fn create_cross_platform_task(task_id: &str) -> DetectionTask {
+    DetectionTask {
+        task_id: task_id.to_owned(),
+        task_type: TaskType::EnumerateProcesses.into(),
+        process_filter: None,
+        hash_check: None,
+        metadata: Some("cross-platform test".to_owned()),
+    }
+}
+
+/// Test basic cross-platform functionality
+#[tokio::test]
+async fn test_basic_cross_platform_functionality() {
+    let (config, _temp_dir) = create_cross_platform_config("basic_functionality");
+
+    // Start server
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(|task: DetectionTask| async move {
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: None,
+            processes: vec![ProcessRecord {
+                pid: 12345,
+                ppid: Some(1),
+                name: "cross_platform_test".to_owned(),
+                executable_path: Some("/usr/bin/test".to_owned()),
+                command_line: vec!["test".to_owned(), "--cross-platform".to_owned()],
+                start_time: Some(chrono::Utc::now().timestamp()),
+                cpu_usage: Some(15.5),
+                memory_usage: Some(2048 * 1024),
+                executable_hash: Some("abcdef123456".to_owned()),
+                hash_algorithm: Some("sha256".to_owned()),
+                user_id: Some("1000".to_owned()),
+                accessible: true,
+                file_exists: true,
+                collection_time: chrono::Utc::now().timestamp_millis(),
+            }],
+            hash_result: None,
+        })
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(300)).await;
+
+    // Test client connection
+    let mut client = InterprocessClient::new(config.clone());
+    let task = create_cross_platform_task("basic_test");
+
+    let result = timeout(Duration::from_secs(10), client.send_task(task))
+        .await
+        .expect("Basic cross-platform test timed out")
+        .expect("Basic cross-platform test failed");
+
+    assert!(result.success);
+    assert_eq!(result.task_id, "basic_test");
+    assert_eq!(result.processes.len(), 1);
+    assert_eq!(result.processes.first().map(|p| p.pid), Some(12345));
+    assert_eq!(
+        result.processes.first().map(|p| &p.name),
+        Some(&"cross_platform_test".to_string())
+    );
+
+    server.stop();
+}
+
+/// Test endpoint path validation across platforms
+#[tokio::test]
+async fn test_endpoint_path_validation() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+
+    // Test valid endpoint paths for current platform
+    let valid_endpoints = create_valid_endpoint_paths(&temp_dir);
+
+    for (test_name, endpoint_path) in valid_endpoints {
+        let config = IpcConfig {
+            transport: TransportType::Interprocess,
+            endpoint_path: endpoint_path.clone(),
+            max_frame_bytes: 1024 * 1024,
+            accept_timeout_ms: 2000,
+            read_timeout_ms: 5000,
+            write_timeout_ms: 5000,
+            max_connections: 4,
+        };
+
+        // Should be able to create server with valid endpoint
+        let server = InterprocessServer::new(config.clone());
+
+        // Server creation should succeed (constructor doesn't return Result)
+        drop(server);
+
+        println!(
+            "Valid endpoint test '{}' passed: {}",
+            test_name, endpoint_path
+        );
+    }
+}
+
+/// Create valid endpoint paths for the current platform
+fn create_valid_endpoint_paths(temp_dir: &TempDir) -> Vec<(String, String)> {
+    let mut endpoints = vec![];
+
+    #[cfg(unix)]
+    {
+        // Unix domain socket paths
+        endpoints.push((
+            "simple_socket".to_owned(),
+            temp_dir
+                .path()
+                .join("simple.sock")
+                .to_string_lossy()
+                .to_string(),
+        ));
+
+        endpoints.push((
+            "nested_socket".to_owned(),
+            temp_dir
+                .path()
+                .join("nested")
+                .join("path.sock")
+                .to_string_lossy()
+                .to_string(),
+        ));
+
+        endpoints.push((
+            "long_name_socket".to_owned(),
+            temp_dir
+                .path()
+                .join("very_long_socket_name_for_testing.sock")
+                .to_string_lossy()
+                .to_string(),
+        ));
+    };
+
+    #[cfg(windows)]
+    {
+        // Windows named pipe paths
+        let base_name = temp_dir
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("test");
+
+        endpoints.push((
+            "simple_pipe".to_owned(),
+            format!(r"\\.\pipe\sentineld\simple-{}", base_name),
+        ));
+
+        endpoints.push((
+            "nested_pipe".to_owned(),
+            format!(r"\\.\pipe\sentineld\nested\path-{}", base_name),
+        ));
+
+        endpoints.push((
+            "long_name_pipe".to_owned(),
+            format!(
+                r"\\.\pipe\sentineld\very-long-pipe-name-for-testing-{}",
+                base_name
+            ),
+        ));
+    }
+
+    endpoints
+}
+
+/// Test platform-specific error handling
+#[tokio::test]
+async fn test_platform_specific_error_handling() {
+    let (config, _temp_dir) = create_cross_platform_config("error_handling");
+
+    // Test connection to non-existent server
+    let mut client = InterprocessClient::new(config.clone());
+    let task = create_cross_platform_task("error_test");
+
+    let result = timeout(Duration::from_secs(3), client.send_task(task)).await;
+
+    // Should fail with platform-appropriate error
+    match result {
+        Ok(Err(e)) => {
+            // Verify error is appropriate for platform
+            let error_msg = e.to_string();
+
+            #[cfg(unix)]
+            {
+                // Unix should report connection refused or no such file
+                assert!(
+                    error_msg.contains("Connection refused")
+                        || error_msg.contains("No such file")
+                        || error_msg.contains("Connection failed"),
+                    "Unix error should indicate connection failure: {error_msg}"
+                );
+            }
+
+            #[cfg(windows)]
+            {
+                // Windows should report pipe not available or similar
+                assert!(
+                    error_msg.contains("pipe")
+                        || error_msg.contains("not available")
+                        || error_msg.contains("Connection failed"),
+                    "Windows error should indicate pipe unavailable: {error_msg}"
+                );
+            }
+        }
+        Ok(Ok(_)) => {
+            panic!("Should not succeed connecting to non-existent server");
+        }
+        Err(_) => {
+            // Timeout is also acceptable
+            println!("Connection attempt timed out (acceptable)");
+        }
+    }
+}
+
+/// Test concurrent connections across platforms
+#[tokio::test]
+async fn test_cross_platform_concurrent_connections() {
+    let (config, _temp_dir) = create_cross_platform_config("concurrent_connections");
+
+    // Start server
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(|task: DetectionTask| async move {
+        // Add small delay to test concurrency
+        sleep(Duration::from_millis(100)).await;
+
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: None,
+            processes: vec![],
+            hash_result: None,
+        })
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(300)).await;
+
+    // Test concurrent connections
+    let num_concurrent = 4;
+    let mut handles = vec![];
+
+    for i in 0..num_concurrent {
+        let client_config = config.clone();
+
+        let handle = tokio::spawn(async move {
+            let mut client = InterprocessClient::new(client_config);
+            let task = create_cross_platform_task(&format!("concurrent_{}", i));
+
+            timeout(Duration::from_secs(10), client.send_task(task)).await
+        });
+
+        handles.push(handle);
+    }
+
+    // Wait for all connections to complete
+    let mut successful_connections = 0;
+
+    for (i, handle) in handles.into_iter().enumerate() {
+        match handle.await {
+            Ok(Ok(Ok(result))) => {
+                assert!(result.success);
+                assert_eq!(result.task_id, format!("concurrent_{}", i));
+                successful_connections += 1;
+            }
+            Ok(Ok(Err(e))) => {
+                eprintln!("Connection {} failed: {}", i, e);
+            }
+            Ok(Err(_)) => {
+                eprintln!("Connection {} timed out", i);
+            }
+            Err(e) => {
+                eprintln!("Connection {} panicked: {}", i, e);
+            }
+        }
+    }
+
+    assert!(
+        successful_connections >= (num_concurrent as usize).div_euclid(2),
+        "At least half of concurrent connections should succeed: {} / {}",
+        successful_connections,
+        num_concurrent
+    );
+
+    server.stop();
+}
+
+/// Test large message handling across platforms
+#[tokio::test]
+async fn test_cross_platform_large_messages() {
+    let (config, _temp_dir) = create_cross_platform_config("large_messages");
+
+    // Start server
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(|task: DetectionTask| async move {
+        // Create large response with many process records
+        let mut processes = vec![];
+        for i in 0..500 {
+            processes.push(ProcessRecord {
+                pid: i,
+                ppid: Some(i.saturating_sub(1)),
+                name: format!("large_test_process_{}", i),
+                executable_path: Some(format!("/usr/bin/large_test_{}", i)),
+                command_line: vec![
+                    format!("large_test_{}", i),
+                    "--large-message-test".to_owned(),
+                    format!("--process-id={}", i),
+                ],
+                start_time: Some(chrono::Utc::now().timestamp()),
+                cpu_usage: Some(10.0 + f64::from(i % 90)),
+                memory_usage: Some(1024 * 1024 * (u64::from(i) + 1)),
+                executable_hash: Some(format!("large_hash_{:08x}", i)),
+                hash_algorithm: Some("sha256".to_owned()),
+                user_id: Some("1000".to_owned()),
+                accessible: true,
+                file_exists: true,
+                collection_time: chrono::Utc::now().timestamp_millis(),
+            });
+        }
+
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: None,
+            processes,
+            hash_result: None,
+        })
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(300)).await;
+
+    // Send large message request
+    let mut client = InterprocessClient::new(config.clone());
+    let task = create_cross_platform_task("large_message_test");
+
+    let result = timeout(Duration::from_secs(30), client.send_task(task))
+        .await
+        .expect("Large message test timed out")
+        .expect("Large message test failed");
+
+    assert!(result.success);
+    assert_eq!(result.task_id, "large_message_test");
+    assert_eq!(result.processes.len(), 500);
+
+    // Verify all process records are intact
+    for (i, process) in result.processes.iter().enumerate() {
+        assert_eq!(process.pid, i as u32);
+        assert_eq!(process.name, format!("large_test_process_{}", i));
+        assert!(process.executable_hash.is_some());
+    }
+
+    server.stop();
+}
+
+/// Test server restart behavior across platforms
+#[tokio::test]
+async fn test_cross_platform_server_restart() {
+    let (config, _temp_dir) = create_cross_platform_config("server_restart");
+
+    // Start first server instance
+    let mut server1 = InterprocessServer::new(config.clone());
+
+    server1.set_handler(|task: DetectionTask| async move {
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: Some("first_server".to_owned()),
+            processes: vec![],
+            hash_result: None,
+        })
+    });
+
+    server1.start().await.expect("Failed to start first server");
+    sleep(Duration::from_millis(300)).await;
+
+    // Test connection to first server
+    let mut client1 = InterprocessClient::new(config.clone());
+    let task1 = create_cross_platform_task("first_server_test");
+
+    let result1 = timeout(Duration::from_secs(5), client1.send_task(task1))
+        .await
+        .expect("First server test timed out")
+        .expect("First server test failed");
+
+    assert!(result1.success);
+    assert_eq!(result1.error_message, Some("first_server".to_owned()));
+
+    // Stop first server
+    server1.stop();
+    sleep(Duration::from_millis(300)).await;
+
+    // Start second server instance (should reuse endpoint)
+    let mut server2 = InterprocessServer::new(config.clone());
+
+    server2.set_handler(|task: DetectionTask| async move {
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: Some("second_server".to_owned()),
+            processes: vec![],
+            hash_result: None,
+        })
+    });
+
+    server2
+        .start()
+        .await
+        .expect("Failed to start second server");
+    sleep(Duration::from_millis(300)).await;
+
+    // Test connection to second server
+    let mut client2 = InterprocessClient::new(config.clone());
+    let task2 = create_cross_platform_task("second_server_test");
+
+    let result2 = timeout(Duration::from_secs(5), client2.send_task(task2))
+        .await
+        .expect("Second server test timed out")
+        .expect("Second server test failed");
+
+    assert!(result2.success);
+    assert_eq!(result2.error_message, Some("second_server".to_owned()));
+
+    server2.stop();
+}
+
+/// Test platform-specific timeout behavior
+#[tokio::test]
+async fn test_cross_platform_timeout_behavior() {
+    let (mut config, _temp_dir) = create_cross_platform_config("timeout_behavior");
+
+    // Set short timeouts for testing
+    config.read_timeout_ms = 1000;
+    config.write_timeout_ms = 1000;
+
+    // Start server with slow handler
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(|task: DetectionTask| async move {
+        // Simulate slow processing
+        sleep(Duration::from_millis(2000)).await;
+
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: None,
+            processes: vec![],
+            hash_result: None,
+        })
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(300)).await;
+
+    // Test timeout behavior
+    let mut client = InterprocessClient::new(config.clone());
+    let task = create_cross_platform_task("timeout_test");
+
+    let result = timeout(Duration::from_secs(5), client.send_task(task)).await;
+
+    // Should timeout or receive error response
+    match result {
+        Ok(Ok(response)) => {
+            // If we get a response, it should indicate an error or timeout
+            assert!(
+                !response.success || response.error_message.is_some(),
+                "Response should indicate timeout or error"
+            );
+        }
+        Ok(Err(e)) => {
+            // Expected: IPC error due to timeout
+            let error_msg = e.to_string();
+            assert!(
+                error_msg.contains("timeout") || error_msg.contains("Timeout"),
+                "Error should indicate timeout: {}",
+                error_msg
+            );
+        }
+        Err(_) => {
+            // Expected: outer timeout
+        }
+    }
+
+    server.stop();
+}
+
+/// Test platform-specific cleanup behavior
+#[tokio::test]
+async fn test_cross_platform_cleanup() {
+    let (config, _temp_dir) = create_cross_platform_config("cleanup_behavior");
+
+    // Start server
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(|task: DetectionTask| async move {
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: None,
+            processes: vec![],
+            hash_result: None,
+        })
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(300)).await;
+
+    // Verify server is running
+    let mut client = InterprocessClient::new(config.clone());
+    let task = create_cross_platform_task("cleanup_test");
+
+    let result = timeout(Duration::from_secs(5), client.send_task(task))
+        .await
+        .expect("Cleanup test timed out")
+        .expect("Cleanup test failed");
+
+    assert!(result.success);
+
+    // Check platform-specific resources before cleanup
+    #[cfg(unix)]
+    {
+        let socket_path = std::path::Path::new(&config.endpoint_path);
+        assert!(
+            socket_path.exists(),
+            "Socket file should exist before cleanup"
+        );
+    };
+
+    // Stop server and verify cleanup
+    server.stop();
+    sleep(Duration::from_millis(300)).await;
+
+    // Check platform-specific cleanup
+    #[cfg(unix)]
+    {
+        let socket_path = std::path::Path::new(&config.endpoint_path);
+        assert!(!socket_path.exists(), "Socket file should be cleaned up");
+    };
+
+    // Verify server is no longer accepting connections
+    let mut post_cleanup_client = InterprocessClient::new(config.clone());
+    let post_cleanup_task = create_cross_platform_task("post_cleanup_test");
+
+    let post_cleanup_result = timeout(
+        Duration::from_secs(2),
+        post_cleanup_client.send_task(post_cleanup_task),
+    )
+    .await;
+
+    assert!(
+        post_cleanup_result.is_err() || post_cleanup_result.is_ok_and(|r| r.is_err()),
+        "Should not be able to connect after cleanup"
+    );
+}

--- a/sentinel-lib/tests/ipc_integration.rs
+++ b/sentinel-lib/tests/ipc_integration.rs
@@ -58,6 +58,7 @@ mod tests {
             read_timeout_ms: 5000,
             write_timeout_ms: 5000,
             max_connections: 5, // Allow more concurrent connections
+            panic_strategy: sentinel_lib::ipc::PanicStrategy::Unwind,
         };
 
         (config, temp_dir)
@@ -114,7 +115,7 @@ mod tests {
         assert!(result.error_message.is_none());
 
         // Clean up
-        server.stop();
+        let _result = server.graceful_shutdown().await;
     }
 
     #[tokio::test]
@@ -154,7 +155,7 @@ mod tests {
         );
 
         // Clean up
-        server.stop();
+        let _result = server.graceful_shutdown().await;
     }
 
     #[tokio::test]
@@ -316,7 +317,7 @@ mod tests {
         );
 
         // Clean up
-        server.stop();
+        let _result = server.graceful_shutdown().await;
     }
 
     /// Test cross-platform endpoint creation
@@ -350,6 +351,7 @@ mod tests {
             read_timeout_ms: 5000,
             write_timeout_ms: 5000,
             max_connections: 5,
+            panic_strategy: sentinel_lib::ipc::PanicStrategy::Unwind,
         };
 
         let _server = InterprocessServer::new(config.clone());

--- a/sentinel-lib/tests/ipc_integration.rs
+++ b/sentinel-lib/tests/ipc_integration.rs
@@ -18,7 +18,7 @@
 mod tests {
     use sentinel_lib::ipc::codec::IpcError;
     use sentinel_lib::ipc::interprocess_transport::{InterprocessClient, InterprocessServer};
-    use sentinel_lib::ipc::{Crc32Variant, IpcConfig, TransportType};
+    use sentinel_lib::ipc::{IpcConfig, TransportType};
     use sentinel_lib::proto::{DetectionResult, DetectionTask, TaskType};
     use std::time::Duration;
     use tempfile::TempDir;
@@ -58,7 +58,6 @@ mod tests {
             read_timeout_ms: 5000,
             write_timeout_ms: 5000,
             max_connections: 5, // Allow more concurrent connections
-            crc32_variant: Crc32Variant::Ieee,
         };
 
         (config, temp_dir)
@@ -351,7 +350,6 @@ mod tests {
             read_timeout_ms: 5000,
             write_timeout_ms: 5000,
             max_connections: 5,
-            crc32_variant: Crc32Variant::Ieee,
         };
 
         let _server = InterprocessServer::new(config.clone());

--- a/sentinel-lib/tests/ipc_property_based_tests.rs
+++ b/sentinel-lib/tests/ipc_property_based_tests.rs
@@ -1,0 +1,478 @@
+//! Property-based tests for IPC codec robustness
+//!
+//! This test suite uses proptest to generate random inputs and validate
+//! codec behavior with malformed inputs, ensuring maximum resilience and security.
+
+#![allow(
+    clippy::expect_used,
+    clippy::str_to_string,
+    clippy::as_conversions,
+    clippy::uninlined_format_args,
+    clippy::use_debug,
+    clippy::shadow_reuse,
+    clippy::shadow_unrelated,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::wildcard_enum_match_arm,
+    clippy::match_same_arms,
+    clippy::ignored_unit_patterns
+)]
+
+use proptest::prelude::*;
+use sentinel_lib::ipc::codec::{IpcCodec, IpcError};
+use sentinel_lib::proto::{DetectionResult, DetectionTask, ProcessRecord, TaskType};
+use std::io::Cursor;
+use tokio::io::{DuplexStream, duplex};
+use tokio::time::Duration;
+
+/// Strategy for generating valid detection tasks
+fn detection_task_strategy() -> impl Strategy<Value = DetectionTask> {
+    (
+        "[a-zA-Z0-9_-]{1,50}",
+        prop::option::of("[a-zA-Z0-9 ]{0,100}"),
+    )
+        .prop_map(|(task_id, metadata)| DetectionTask {
+            task_id,
+            task_type: TaskType::EnumerateProcesses as i32,
+            process_filter: None,
+            hash_check: None,
+            metadata,
+        })
+}
+
+/// Strategy for generating process records
+fn process_record_strategy() -> impl Strategy<Value = ProcessRecord> {
+    any::<u32>().prop_map(|pid| ProcessRecord {
+        pid,
+        ppid: Some(pid.saturating_sub(1)),
+        name: format!("test_process_{}", pid),
+        executable_path: Some(format!("/usr/bin/test_{}", pid)),
+        command_line: vec![format!("test_{}", pid)],
+        start_time: Some(chrono::Utc::now().timestamp()),
+        cpu_usage: Some(25.5),
+        memory_usage: Some(1024 * 1024),
+        executable_hash: Some(format!("hash_{:08x}", pid)),
+        hash_algorithm: Some("sha256".to_owned()),
+        user_id: Some("1000".to_owned()),
+        accessible: true,
+        file_exists: true,
+        collection_time: chrono::Utc::now().timestamp_millis(),
+    })
+}
+
+/// Strategy for generating detection results
+fn detection_result_strategy() -> impl Strategy<Value = DetectionResult> {
+    (
+        "[a-zA-Z0-9_-]{1,50}",
+        any::<bool>(),
+        prop::option::of("[a-zA-Z0-9 ]{0,200}"),
+        prop::collection::vec(process_record_strategy(), 0..5),
+    )
+        .prop_map(
+            |(task_id, success, error_message, processes)| DetectionResult {
+                task_id,
+                success,
+                error_message,
+                processes,
+                hash_result: None,
+            },
+        )
+}
+
+/// Strategy for generating random byte arrays (malformed data)
+fn malformed_data_strategy() -> impl Strategy<Value = Vec<u8>> {
+    prop::collection::vec(any::<u8>(), 0..1024)
+}
+
+/// Strategy for generating corrupted frame headers
+fn corrupted_frame_strategy() -> impl Strategy<Value = Vec<u8>> {
+    (
+        any::<u32>(),
+        any::<u32>(),
+        prop::collection::vec(any::<u8>(), 0..100),
+    )
+        .prop_map(|(length, crc32, data)| {
+            let mut frame = Vec::new();
+            frame.extend_from_slice(&length.to_le_bytes());
+            frame.extend_from_slice(&crc32.to_le_bytes());
+            frame.extend_from_slice(&data);
+            frame
+        })
+}
+
+/// Create a test codec with default settings
+fn create_test_codec() -> IpcCodec {
+    IpcCodec::new(1024 * 1024)
+}
+
+/// Create a duplex stream pair for testing
+fn create_test_streams() -> (DuplexStream, DuplexStream) {
+    duplex(8192)
+}
+
+proptest! {
+    /// Test that valid messages can be encoded and decoded correctly
+    #[test]
+    fn test_valid_message_roundtrip(task in detection_task_strategy()) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut codec = create_test_codec();
+            let (mut client, mut server) = create_test_streams();
+            let timeout_duration = Duration::from_secs(1);
+
+            // Write message
+            let write_result = codec.write_message(&mut client, &task, timeout_duration).await;
+            prop_assert!(write_result.is_ok(), "Failed to write valid message: {:?}", write_result);
+
+            // Read message back
+            let read_result: Result<DetectionTask, _> = codec.read_message(&mut server, timeout_duration).await;
+            prop_assert!(read_result.is_ok(), "Failed to read valid message: {:?}", read_result);
+
+            let decoded_task = read_result.unwrap();
+            prop_assert_eq!(task.task_id, decoded_task.task_id);
+            prop_assert_eq!(task.task_type, decoded_task.task_type);
+            prop_assert_eq!(task.metadata, decoded_task.metadata);
+
+            Ok(())
+        })?;
+    }
+
+    /// Test that detection results can be encoded and decoded correctly
+    #[test]
+    fn test_detection_result_roundtrip(result in detection_result_strategy()) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut codec = create_test_codec();
+            let (mut client, mut server) = create_test_streams();
+            let timeout_duration = Duration::from_secs(1);
+
+            // Write result
+            let write_result = codec.write_message(&mut client, &result, timeout_duration).await;
+            prop_assert!(write_result.is_ok(), "Failed to write valid result: {:?}", write_result);
+
+            // Read result back
+            let read_result: Result<DetectionResult, _> = codec.read_message(&mut server, timeout_duration).await;
+            prop_assert!(read_result.is_ok(), "Failed to read valid result: {:?}", read_result);
+
+            let decoded_result = read_result.unwrap();
+            prop_assert_eq!(result.task_id, decoded_result.task_id);
+            prop_assert_eq!(result.success, decoded_result.success);
+            prop_assert_eq!(result.error_message, decoded_result.error_message);
+            prop_assert_eq!(result.processes.len(), decoded_result.processes.len());
+
+            Ok(())
+        })?;
+    }
+
+    /// Test that malformed data is properly rejected
+    #[test]
+    fn test_malformed_data_rejection(malformed_data in malformed_data_strategy()) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut codec = create_test_codec();
+            let mut cursor = Cursor::new(malformed_data);
+            let timeout_duration = Duration::from_millis(100);
+
+            // Try to read malformed data as a DetectionTask
+            let read_result: Result<DetectionTask, _> = codec.read_message(&mut cursor, timeout_duration).await;
+
+            // Should fail with appropriate error
+            prop_assert!(read_result.is_err(), "Malformed data should be rejected");
+
+            match read_result.unwrap_err() {
+                IpcError::InvalidLength { .. } |
+                IpcError::TooLarge { .. } |
+                IpcError::CrcMismatch { .. } |
+                IpcError::Decode(_) |
+                IpcError::PeerClosed |
+                IpcError::Timeout => {
+                    // These are all acceptable error types for malformed data
+                }
+                other => {
+                    prop_assert!(false, "Unexpected error type for malformed data: {:?}", other);
+                }
+            }
+
+            Ok(())
+        })?;
+    }
+
+    /// Test that corrupted frames are detected and rejected
+    #[test]
+    fn test_corrupted_frame_detection(corrupted_frame in corrupted_frame_strategy()) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut codec = create_test_codec();
+            let mut cursor = Cursor::new(corrupted_frame);
+            let timeout_duration = Duration::from_millis(100);
+
+            // Try to read corrupted frame
+            let read_result: Result<DetectionTask, _> = codec.read_message(&mut cursor, timeout_duration).await;
+
+            // Should fail (corrupted frames should be detected)
+            prop_assert!(read_result.is_err(), "Corrupted frame should be rejected");
+
+            Ok(())
+        })?;
+    }
+
+    /// Test CRC32 calculation consistency
+    #[test]
+    fn test_crc32_consistency(data in prop::collection::vec(any::<u8>(), 0..1000)) {
+        let _codec1 = IpcCodec::new(1024 * 1024);
+        let _codec2 = IpcCodec::new(1024 * 1024);
+
+        // Calculate CRC32C with both codecs
+        let crc1 = crc32c::crc32c(&data);
+        let crc2 = crc32c::crc32c(&data);
+
+        // Should be identical
+        prop_assert_eq!(crc1, crc2, "CRC32 calculation should be consistent");
+
+        // Should be deterministic (same input -> same output)
+        let crc3 = crc32c::crc32c(&data);
+        prop_assert_eq!(crc1, crc3, "CRC32 calculation should be deterministic");
+    }
+
+    /// Test frame size limits
+    #[test]
+    fn test_frame_size_limits(size_limit in 100_usize..10000) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let codec = IpcCodec::new(size_limit);
+            let (mut client, _server) = create_test_streams();
+            let timeout_duration = Duration::from_secs(1);
+
+            // Create a task with metadata larger than the limit
+            let large_metadata = "x".repeat(size_limit + 100);
+            let large_task = DetectionTask {
+                task_id: "test".to_owned(),
+                task_type: TaskType::EnumerateProcesses as i32,
+                process_filter: None,
+                hash_check: None,
+                metadata: Some(large_metadata),
+            };
+
+            // Should fail with TooLarge error
+            let write_result = codec.write_message(&mut client, &large_task, timeout_duration).await;
+
+            match write_result {
+                Err(IpcError::TooLarge { size, max_size }) => {
+                    prop_assert!(size > max_size, "Size should exceed limit");
+                    prop_assert_eq!(max_size, size_limit, "Max size should match configured limit");
+                }
+                Err(IpcError::Encode(_)) => {
+                    // Also acceptable - protobuf encoding might fail first
+                }
+                other => {
+                    prop_assert!(false, "Expected TooLarge error for oversized message, got: {:?}", other);
+                }
+            }
+
+            Ok(())
+        })?;
+    }
+
+    /// Test timeout behavior with slow operations
+    #[test]
+    fn test_timeout_behavior(timeout_ms in 10_u64..100) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut codec = create_test_codec();
+            let (_client, mut server) = create_test_streams();
+            let timeout_duration = Duration::from_millis(timeout_ms);
+
+            // Try to read from empty stream with short timeout
+            let read_result: Result<DetectionTask, _> = codec.read_message(&mut server, timeout_duration).await;
+
+            // Should timeout
+            match read_result {
+                Err(IpcError::Timeout) => {
+                    // Expected
+                }
+                Err(IpcError::PeerClosed) => {
+                    // Also acceptable - stream might be closed
+                }
+                other => {
+                    prop_assert!(false, "Expected timeout or peer closed, got: {:?}", other);
+                }
+            }
+
+            Ok(())
+        })?;
+    }
+
+    /// Test that zero-length messages are rejected
+    #[test]
+    fn test_zero_length_rejection(_dummy in any::<u8>()) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut codec = create_test_codec();
+            let timeout_duration = Duration::from_millis(100);
+
+            // Create a frame with zero length
+            let zero_frame = vec![
+                0, 0, 0, 0,  // length = 0
+                0, 0, 0, 0,  // crc32 = 0
+                // no data
+            ];
+
+            let mut cursor = Cursor::new(zero_frame);
+            let read_result: Result<DetectionTask, _> = codec.read_message(&mut cursor, timeout_duration).await;
+
+            // Should fail with InvalidLength error
+            match read_result {
+                Err(IpcError::InvalidLength { length }) => {
+                    prop_assert_eq!(length, 0, "Should detect zero length");
+                }
+                other => {
+                    prop_assert!(false, "Expected InvalidLength error for zero-length message, got: {:?}", other);
+                }
+            }
+
+            Ok(())
+        })?;
+    }
+
+    /// Test CRC32 mismatch detection
+    #[test]
+    fn test_crc_mismatch_detection(data in prop::collection::vec(any::<u8>(), 1..100)) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut codec = create_test_codec();
+            let timeout_duration = Duration::from_millis(100);
+
+        // Calculate correct CRC32C
+        let correct_crc = crc32c::crc32c(&data);
+            let wrong_crc = correct_crc.wrapping_add(1); // Corrupt the CRC
+
+            // Create frame with wrong CRC
+            let mut frame = Vec::new();
+            frame.extend_from_slice(&(data.len() as u32).to_le_bytes());
+            frame.extend_from_slice(&wrong_crc.to_le_bytes());
+            frame.extend_from_slice(&data);
+
+            let mut cursor = Cursor::new(frame);
+            let read_result: Result<DetectionTask, _> = codec.read_message(&mut cursor, timeout_duration).await;
+
+            // Should fail with CrcMismatch error
+            match read_result {
+                Err(IpcError::CrcMismatch { expected, actual }) => {
+                    prop_assert_eq!(expected, wrong_crc, "Expected CRC should match frame");
+                    prop_assert_eq!(actual, correct_crc, "Actual CRC should be calculated correctly");
+                }
+                other => {
+                    prop_assert!(false, "Expected CrcMismatch error, got: {:?}", other);
+                }
+            }
+
+            Ok(())
+        })?;
+    }
+}
+
+/// Additional manual tests for edge cases
+#[cfg(test)]
+mod edge_case_tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn test_partial_frame_handling() {
+        let mut codec = create_test_codec();
+        let (mut client, mut server) = create_test_streams();
+        let timeout_duration = Duration::from_millis(100);
+
+        // Write partial frame header (only 4 bytes instead of 8)
+        let partial_header = vec![1, 0, 0, 0]; // length = 1, but missing CRC
+        client
+            .write_all(&partial_header)
+            .await
+            .expect("Failed to write partial header");
+
+        // Try to read - should timeout or fail
+        let read_result: Result<DetectionTask, _> =
+            codec.read_message(&mut server, timeout_duration).await;
+        assert!(read_result.is_err(), "Partial frame should be rejected");
+    }
+
+    #[tokio::test]
+    async fn test_incomplete_message_handling() {
+        let mut codec = create_test_codec();
+        let (mut client, mut server) = create_test_streams();
+        let timeout_duration = Duration::from_millis(100);
+
+        // Write frame header claiming 100 bytes but only provide 50
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&100_u32.to_le_bytes()); // claim 100 bytes
+        frame.extend_from_slice(&0_u32.to_le_bytes()); // CRC = 0
+        frame.extend_from_slice(&[0_u8; 50]); // only 50 bytes
+
+        client
+            .write_all(&frame)
+            .await
+            .expect("Failed to write incomplete frame");
+
+        // Try to read - should timeout waiting for remaining bytes
+        let read_result: Result<DetectionTask, _> =
+            codec.read_message(&mut server, timeout_duration).await;
+        assert!(
+            read_result.is_err(),
+            "Incomplete message should be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_maximum_frame_size_boundary() {
+        let max_size = 1024;
+        let codec = IpcCodec::new(max_size);
+        let (mut client, _server) = create_test_streams();
+        let timeout_duration = Duration::from_secs(1);
+
+        // Create task exactly at the boundary
+        let boundary_metadata = "x".repeat(max_size - 100); // Leave room for other fields
+        let boundary_task = DetectionTask {
+            task_id: "boundary_test".to_owned(),
+            task_type: TaskType::EnumerateProcesses as i32,
+            process_filter: None,
+            hash_check: None,
+            metadata: Some(boundary_metadata),
+        };
+
+        // This might succeed or fail depending on exact serialized size
+        let write_result = codec
+            .write_message(&mut client, &boundary_task, timeout_duration)
+            .await;
+
+        // Either way, it should not panic or cause undefined behavior
+        match write_result {
+            Ok(_) => {
+                // Message was within limits
+            }
+            Err(IpcError::TooLarge { .. }) => {
+                // Message exceeded limits
+            }
+            Err(other) => {
+                panic!("Unexpected error at boundary: {:?}", other);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_crc32c_consistency() {
+        let data = b"test data for CRC32C consistency";
+
+        let crc1 = crc32c::crc32c(data);
+        let crc2 = crc32c::crc32c(data);
+
+        // CRC32C should be deterministic
+        assert_eq!(crc1, crc2, "CRC32C should produce consistent results");
+
+        // Should be non-zero for non-empty data
+        if !data.is_empty() {
+            assert_ne!(crc1, 0, "CRC32C should not be zero for non-empty data");
+        }
+    }
+}

--- a/sentinel-lib/tests/ipc_security_validation.rs
+++ b/sentinel-lib/tests/ipc_security_validation.rs
@@ -1,0 +1,761 @@
+//! Security validation tests for IPC communication
+//!
+//! This test suite validates security aspects of the IPC implementation including:
+//! - Socket permissions and access control
+//! - Connection limits and resource management
+//! - Input validation and attack resistance
+//! - Privilege separation and isolation
+
+#![allow(
+    clippy::expect_used,
+    clippy::str_to_string,
+    clippy::as_conversions,
+    clippy::uninlined_format_args,
+    clippy::use_debug,
+    clippy::shadow_reuse,
+    clippy::shadow_unrelated,
+    clippy::single_match_else,
+    clippy::case_sensitive_file_extension_comparisons,
+    clippy::redundant_else,
+    clippy::panic
+)]
+
+use interprocess::local_socket::tokio::prelude::*;
+use sentinel_lib::ipc::codec::{IpcCodec, IpcError};
+use sentinel_lib::ipc::interprocess_transport::{InterprocessClient, InterprocessServer};
+use sentinel_lib::ipc::{IpcConfig, TransportType};
+use sentinel_lib::proto::{DetectionResult, DetectionTask, ProcessRecord, TaskType};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::Barrier;
+use tokio::time::{sleep, timeout};
+
+/// Create a test configuration for security tests
+fn create_security_test_config(test_name: &str) -> (IpcConfig, TempDir) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let endpoint_path = create_security_test_endpoint(&temp_dir, test_name);
+
+    let config = IpcConfig {
+        transport: TransportType::Interprocess,
+        endpoint_path,
+        max_frame_bytes: 1024 * 1024, // 1MB limit for security tests
+        accept_timeout_ms: 2000,
+        read_timeout_ms: 5000,
+        write_timeout_ms: 5000,
+        max_connections: 3, // Low limit for testing
+    };
+
+    (config, temp_dir)
+}
+
+/// Create platform-specific security test endpoint
+fn create_security_test_endpoint(temp_dir: &TempDir, test_name: &str) -> String {
+    #[cfg(unix)]
+    {
+        temp_dir
+            .path()
+            .join(format!("security_{}.sock", test_name))
+            .to_string_lossy()
+            .to_string()
+    }
+    #[cfg(windows)]
+    {
+        let dir_name = temp_dir
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("security");
+        format!(r"\\.\pipe\sentineld\security-{}-{}", test_name, dir_name)
+    }
+}
+
+/// Create a test detection task
+fn create_security_test_task(task_id: &str) -> DetectionTask {
+    DetectionTask {
+        task_id: task_id.to_owned(),
+        task_type: TaskType::EnumerateProcesses.into(),
+        process_filter: None,
+        hash_check: None,
+        metadata: Some("security validation test".to_owned()),
+    }
+}
+
+/// Test Unix socket permissions (Unix only)
+#[cfg(unix)]
+#[tokio::test]
+async fn test_unix_socket_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (config, _temp_dir) = create_security_test_config("socket_permissions");
+
+    // Start server
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(|task: DetectionTask| async move {
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: None,
+            processes: vec![],
+            hash_result: None,
+        })
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Check socket file permissions
+    let socket_path = std::path::Path::new(&config.endpoint_path);
+    assert!(socket_path.exists(), "Socket file should exist");
+
+    let metadata = std::fs::metadata(socket_path).expect("Failed to get socket metadata");
+    let permissions = metadata.permissions();
+    let mode = permissions.mode();
+
+    // Socket should have owner read/write only (0600)
+    assert_eq!(
+        mode & 0o777,
+        0o600,
+        "Socket permissions should be 0600 (owner only), got {:o}",
+        mode & 0o777
+    );
+
+    // Check parent directory permissions
+    if let Some(parent_dir) = socket_path.parent() {
+        if parent_dir != std::path::Path::new("/tmp") && parent_dir.exists() {
+            let parent_metadata =
+                std::fs::metadata(parent_dir).expect("Failed to get parent dir metadata");
+            let parent_permissions = parent_metadata.permissions();
+            let parent_mode = parent_permissions.mode();
+
+            // Parent directory should have at least owner read/write/execute (0700)
+            // In test environments, it might have additional permissions (like 0755)
+            assert!(
+                (parent_mode & 0o700) == 0o700,
+                "Parent directory should have at least owner read/write/execute permissions, got {:o}",
+                parent_mode & 0o777
+            );
+        }
+    }
+
+    // Verify client can connect with proper permissions
+    let mut client = InterprocessClient::new(config.clone());
+    let task = create_security_test_task("permission_test");
+
+    let result = timeout(Duration::from_secs(5), client.send_task(task))
+        .await
+        .expect("Permission test timed out")
+        .expect("Permission test failed");
+
+    assert!(result.success);
+
+    server.stop();
+
+    // Verify socket cleanup
+    sleep(Duration::from_millis(100)).await;
+    assert!(!socket_path.exists(), "Socket file should be cleaned up");
+}
+
+/// Test connection limits enforcement
+#[tokio::test]
+async fn test_connection_limits_enforcement() {
+    let (mut config, _temp_dir) = create_security_test_config("connection_limits");
+
+    // Set very low connection limit
+    config.max_connections = 2;
+
+    let connection_counter = Arc::new(AtomicU32::new(0));
+    let handler_counter = Arc::clone(&connection_counter);
+
+    // Start server with connection tracking
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(move |task: DetectionTask| {
+        let counter = Arc::clone(&handler_counter);
+        async move {
+            let conn_num = counter.fetch_add(1, Ordering::SeqCst);
+
+            // Hold connection open to test limits
+            sleep(Duration::from_millis(1000)).await;
+
+            Ok(DetectionResult {
+                task_id: task.task_id,
+                success: true,
+                error_message: None,
+                processes: vec![ProcessRecord {
+                    pid: conn_num,
+                    ppid: None,
+                    name: format!("test_process_{}", conn_num),
+                    executable_path: None,
+                    command_line: vec![],
+                    start_time: None,
+                    cpu_usage: None,
+                    memory_usage: None,
+                    executable_hash: None,
+                    hash_algorithm: None,
+                    user_id: None,
+                    accessible: true,
+                    file_exists: true,
+                    collection_time: chrono::Utc::now().timestamp_millis(),
+                }],
+                hash_result: None,
+            })
+        }
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Attempt more connections than the limit
+    let num_clients = 5; // More than the limit of 2
+    let barrier = Arc::new(Barrier::new(num_clients));
+    let mut handles = vec![];
+
+    for i in 0..num_clients {
+        let client_config = config.clone();
+        let client_barrier = Arc::clone(&barrier);
+
+        let handle = tokio::spawn(async move {
+            // Wait for all clients to be ready
+            client_barrier.wait().await;
+
+            let mut client = InterprocessClient::new(client_config);
+            let task = create_security_test_task(&format!("limit_test_{}", i));
+
+            let start_time = Instant::now();
+            let result = timeout(Duration::from_secs(3), client.send_task(task)).await;
+            let duration = start_time.elapsed();
+
+            (i, result, duration)
+        });
+
+        handles.push(handle);
+    }
+
+    // Wait for all attempts to complete
+    let mut successful_connections = 0;
+    let mut rejected_connections = 0;
+    let mut timeout_connections = 0;
+
+    for handle in handles {
+        let (client_id, result, duration) = handle.await.expect("Client task failed");
+
+        match result {
+            Ok(Ok(_response)) => {
+                successful_connections += 1;
+                println!("Client {} succeeded in {:?}", client_id, duration);
+            }
+            Ok(Err(e)) => {
+                rejected_connections += 1;
+                println!("Client {} rejected: {} in {:?}", client_id, e, duration);
+            }
+            Err(_) => {
+                timeout_connections += 1;
+                println!("Client {} timed out in {:?}", client_id, duration);
+            }
+        }
+    }
+
+    println!(
+        "Connection limit test results: {} successful, {} rejected, {} timeout (limit: {})",
+        successful_connections, rejected_connections, timeout_connections, config.max_connections
+    );
+
+    // Should have some successful connections but not exceed the limit
+    assert!(
+        successful_connections > 0,
+        "At least some connections should succeed"
+    );
+    assert!(
+        successful_connections <= config.max_connections,
+        "Should not exceed connection limit: {} > {}",
+        successful_connections,
+        config.max_connections
+    );
+
+    // Most connections should be rejected or timeout due to limits
+    assert!(
+        rejected_connections + timeout_connections > 0,
+        "Some connections should be rejected due to limits"
+    );
+
+    server.stop();
+}
+
+/// Test message size limits enforcement
+#[tokio::test]
+async fn test_message_size_limits() {
+    let (mut config, _temp_dir) = create_security_test_config("message_size_limits");
+
+    // Set small message size limit for testing
+    config.max_frame_bytes = 1024; // 1KB limit
+
+    // Start server
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(|task: DetectionTask| async move {
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: None,
+            processes: vec![],
+            hash_result: None,
+        })
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Test with oversized message
+    let mut client = InterprocessClient::new(config.clone());
+    let large_task = DetectionTask {
+        task_id: "oversized_test".to_owned(),
+        task_type: TaskType::EnumerateProcesses.into(),
+        process_filter: None,
+        hash_check: None,
+        metadata: Some("x".repeat(2048)), // Larger than 1KB limit
+    };
+
+    let result = timeout(Duration::from_secs(5), client.send_task(large_task)).await;
+
+    // Should fail due to size limit
+    match result {
+        Ok(Err(IpcError::TooLarge { size, max_size })) => {
+            assert!(size > max_size, "Size should exceed limit");
+            assert_eq!(
+                max_size, config.max_frame_bytes,
+                "Max size should match config"
+            );
+        }
+        Ok(Err(IpcError::Encode(_))) => {
+            // Also acceptable - encoding might fail first
+        }
+        other => {
+            panic!("Expected TooLarge or Encode error for oversized message, got: {other:?}");
+        }
+    }
+
+    // Test with normal-sized message (should succeed)
+    let normal_task = create_security_test_task("normal_test");
+    let normal_result = timeout(Duration::from_secs(5), client.send_task(normal_task))
+        .await
+        .expect("Normal message timed out")
+        .expect("Normal message failed");
+
+    assert!(normal_result.success, "Normal-sized message should succeed");
+
+    server.stop();
+}
+
+/// Test malformed frame attack resistance
+#[tokio::test]
+async fn test_malformed_frame_resistance() {
+    let (config, _temp_dir) = create_security_test_config("malformed_frames");
+
+    // Start server
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(|task: DetectionTask| async move {
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: None,
+            processes: vec![],
+            hash_result: None,
+        })
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Test various malformed frames
+    let malformed_frames = [
+        // Zero length frame
+        vec![0, 0, 0, 0, 0, 0, 0, 0],
+        // Invalid length (too large)
+        vec![0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0],
+        // Partial frame (missing data)
+        vec![10, 0, 0, 0, 0x12, 0x34, 0x56, 0x78, 1, 2, 3], // Claims 10 bytes but only has 3
+        // Corrupted CRC
+        vec![4, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF, 1, 2, 3, 4],
+    ];
+
+    for (i, malformed_frame) in malformed_frames.iter().enumerate() {
+        // Try to send malformed frame directly to socket
+        match LocalSocketStream::connect(
+            create_socket_name(&config).expect("Failed to create socket name"),
+        )
+        .await
+        {
+            Ok(mut stream) => {
+                // Send malformed frame
+                let write_result = stream.write_all(malformed_frame).await;
+
+                if write_result.is_ok() {
+                    // Try to read response (should fail or timeout)
+                    let mut buffer = vec![0_u8; 1024];
+                    let read_result =
+                        timeout(Duration::from_millis(500), stream.read(&mut buffer)).await;
+
+                    // Server should either close connection or timeout
+                    match read_result {
+                        Ok(Ok(0)) => {
+                            // Connection closed (good)
+                            println!("Malformed frame {} caused connection close", i);
+                        }
+                        Ok(Ok(_)) => {
+                            // Got some data back - check if it's an error response
+                            println!("Malformed frame {} got response (may be error)", i);
+                        }
+                        Ok(Err(_)) | Err(_) => {
+                            // Error or timeout (good)
+                            println!("Malformed frame {} caused error/timeout", i);
+                        }
+                    }
+                } else {
+                    println!("Malformed frame {} failed to send", i);
+                }
+            }
+            Err(e) => {
+                println!("Failed to connect for malformed frame test {}: {}", i, e);
+            }
+        }
+    }
+
+    // Verify server is still functional after malformed frame attacks
+    let mut client = InterprocessClient::new(config.clone());
+    let recovery_task = create_security_test_task("recovery_test");
+
+    let recovery_result = timeout(Duration::from_secs(5), client.send_task(recovery_task))
+        .await
+        .expect("Recovery test timed out")
+        .expect("Recovery test failed");
+
+    assert!(
+        recovery_result.success,
+        "Server should recover from malformed frame attacks"
+    );
+
+    server.stop();
+}
+
+/// Helper function to create socket name (platform-specific)
+fn create_socket_name(
+    config: &IpcConfig,
+) -> Result<interprocess::local_socket::Name<'_>, Box<dyn std::error::Error>> {
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::{GenericFilePath, ToFsName};
+        use std::path::Path;
+
+        let path = Path::new(&config.endpoint_path);
+        Ok(path.to_fs_name::<GenericFilePath>()?)
+    }
+    #[cfg(windows)]
+    {
+        use interprocess::local_socket::{GenericNamespaced, ToNsName};
+
+        Ok(config
+            .endpoint_path
+            .clone()
+            .to_ns_name::<GenericNamespaced>()?)
+    }
+}
+
+/// Test timeout-based `DoS` resistance
+#[tokio::test]
+async fn test_timeout_dos_resistance() {
+    let (mut config, _temp_dir) = create_security_test_config("timeout_dos");
+
+    // Set short timeouts for testing
+    config.read_timeout_ms = 1000;
+    config.write_timeout_ms = 1000;
+
+    let slow_request_counter = Arc::new(AtomicU32::new(0));
+    let handler_counter = Arc::clone(&slow_request_counter);
+
+    // Start server with intentionally slow handler
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(move |task: DetectionTask| {
+        let counter = Arc::clone(&handler_counter);
+        async move {
+            let request_num = counter.fetch_add(1, Ordering::SeqCst);
+
+            // First few requests are slow (potential DoS)
+            if request_num < 3 {
+                sleep(Duration::from_millis(2000)).await; // Exceed timeout
+            }
+
+            Ok(DetectionResult {
+                task_id: task.task_id,
+                success: true,
+                error_message: None,
+                processes: vec![],
+                hash_result: None,
+            })
+        }
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Send requests that will timeout
+    let mut timeout_count = 0;
+    let mut success_count = 0;
+
+    for i in 0..5 {
+        let mut client = InterprocessClient::new(config.clone());
+        let task = create_security_test_task(&format!("timeout_dos_{}", i));
+
+        let result = timeout(Duration::from_secs(3), client.send_task(task)).await;
+
+        match result {
+            Ok(Ok(response)) => {
+                if response.success {
+                    success_count += 1;
+                } else {
+                    timeout_count += 1; // Server-side timeout
+                }
+            }
+            Ok(Err(_)) | Err(_) => {
+                timeout_count += 1; // Client-side timeout or error
+            }
+        }
+    }
+
+    println!(
+        "Timeout DoS test: {} timeouts, {} successes",
+        timeout_count, success_count
+    );
+
+    // Should have some timeouts due to slow processing
+    assert!(
+        timeout_count > 0,
+        "Should have some timeouts due to slow processing"
+    );
+
+    // But server should still be responsive for later requests
+    assert!(success_count > 0, "Should have some successful requests");
+
+    server.stop();
+}
+
+/// Test resource exhaustion resistance
+#[tokio::test]
+async fn test_resource_exhaustion_resistance() {
+    let (mut config, _temp_dir) = create_security_test_config("resource_exhaustion");
+
+    // Set limits for resource exhaustion testing
+    config.max_connections = 2;
+    config.max_frame_bytes = 10 * 1024; // 10KB limit
+
+    let resource_counter = Arc::new(AtomicU32::new(0));
+    let handler_counter = Arc::clone(&resource_counter);
+
+    // Start server
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(move |task: DetectionTask| {
+        let counter = Arc::clone(&handler_counter);
+        async move {
+            let request_num = counter.fetch_add(1, Ordering::SeqCst);
+
+            // Simulate resource usage
+            let _memory_usage = vec![0_u8; 1024]; // Allocate some memory
+            sleep(Duration::from_millis(100)).await; // Use some CPU time
+
+            Ok(DetectionResult {
+                task_id: task.task_id,
+                success: true,
+                error_message: None,
+                processes: vec![ProcessRecord {
+                    pid: request_num,
+                    ppid: None,
+                    name: format!("resource_test_{}", request_num),
+                    executable_path: None,
+                    command_line: vec![],
+                    start_time: None,
+                    cpu_usage: None,
+                    memory_usage: None,
+                    executable_hash: None,
+                    hash_algorithm: None,
+                    user_id: None,
+                    accessible: true,
+                    file_exists: true,
+                    collection_time: chrono::Utc::now().timestamp_millis(),
+                }],
+                hash_result: None,
+            })
+        }
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Attempt resource exhaustion with many concurrent requests
+    let num_attackers = 10;
+    let mut handles = vec![];
+
+    for i in 0..num_attackers {
+        let client_config = config.clone();
+
+        let handle = tokio::spawn(async move {
+            let mut client = InterprocessClient::new(client_config);
+            let task = create_security_test_task(&format!("exhaust_{}", i));
+
+            timeout(Duration::from_secs(5), client.send_task(task)).await
+        });
+
+        handles.push(handle);
+    }
+
+    // Wait for all attempts
+    let mut successful_attacks = 0;
+    let mut failed_attacks = 0;
+
+    for (i, handle) in handles.into_iter().enumerate() {
+        match handle.await {
+            Ok(Ok(Ok(_))) => {
+                successful_attacks += 1;
+            }
+            Ok(Ok(Err(_)) | Err(_)) | Err(_) => {
+                failed_attacks += 1;
+                println!("Attack {} failed (expected due to limits)", i);
+            }
+        }
+    }
+
+    println!(
+        "Resource exhaustion test: {} successful, {} failed (limit: {})",
+        successful_attacks, failed_attacks, config.max_connections
+    );
+
+    // Should limit successful attacks due to connection limits
+    assert!(
+        successful_attacks <= config.max_connections,
+        "Should not exceed connection limits during resource exhaustion attack"
+    );
+
+    // Verify server is still functional after attack
+    let mut recovery_client = InterprocessClient::new(config.clone());
+    let recovery_task = create_security_test_task("post_attack_recovery");
+
+    let recovery_result = timeout(
+        Duration::from_secs(5),
+        recovery_client.send_task(recovery_task),
+    )
+    .await
+    .expect("Recovery test timed out")
+    .expect("Recovery test failed");
+
+    assert!(
+        recovery_result.success,
+        "Server should recover from resource exhaustion attack"
+    );
+
+    server.stop();
+}
+
+/// Test CRC32 collision resistance (basic)
+#[tokio::test]
+async fn test_crc32_collision_resistance() {
+    let _codec = IpcCodec::new(1024 * 1024);
+
+    // Test that different data produces different CRC32 values
+    let data_a = b"a".repeat(100);
+    let data_b = b"b".repeat(100);
+    let test_cases = vec![
+        (b"test data 1".as_slice(), b"test data 2".as_slice()),
+        (b"hello world".as_slice(), b"hello world!".as_slice()),
+        (b"".as_slice(), b"x".as_slice()),
+        (data_a.as_slice(), data_b.as_slice()),
+    ];
+
+    for (data1, data2) in test_cases {
+        let crc1 = crc32c::crc32c(data1);
+        let crc2 = crc32c::crc32c(data2);
+
+        assert_ne!(
+            crc1, crc2,
+            "Different data should produce different CRC32 values: {:?} vs {:?}",
+            data1, data2
+        );
+    }
+
+    // Test that identical data produces identical CRC32 values
+    let identical_data = b"identical test data";
+    let crc_a = crc32c::crc32c(identical_data);
+    let crc_b = crc32c::crc32c(identical_data);
+
+    assert_eq!(
+        crc_a, crc_b,
+        "Identical data should produce identical CRC32 values"
+    );
+}
+
+/// Test server shutdown security
+#[tokio::test]
+async fn test_server_shutdown_security() {
+    let (config, _temp_dir) = create_security_test_config("shutdown_security");
+
+    // Start server
+    let mut server = InterprocessServer::new(config.clone());
+
+    server.set_handler(|task: DetectionTask| async move {
+        Ok(DetectionResult {
+            task_id: task.task_id,
+            success: true,
+            error_message: None,
+            processes: vec![],
+            hash_result: None,
+        })
+    });
+
+    server.start().await.expect("Failed to start server");
+    sleep(Duration::from_millis(200)).await;
+
+    // Verify server is running
+    let mut client = InterprocessClient::new(config.clone());
+    let task = create_security_test_task("pre_shutdown");
+
+    let result = timeout(Duration::from_secs(5), client.send_task(task))
+        .await
+        .expect("Pre-shutdown test timed out")
+        .expect("Pre-shutdown test failed");
+
+    assert!(result.success);
+
+    // Stop server
+    server.stop();
+    sleep(Duration::from_millis(200)).await;
+
+    // Verify server properly rejects new connections
+    let mut post_shutdown_client = InterprocessClient::new(config.clone());
+    let post_shutdown_task = create_security_test_task("post_shutdown");
+
+    let post_shutdown_result = timeout(
+        Duration::from_secs(2),
+        post_shutdown_client.send_task(post_shutdown_task),
+    )
+    .await;
+
+    // Should fail to connect
+    assert!(
+        post_shutdown_result.is_err() || post_shutdown_result.is_ok_and(|r| r.is_err()),
+        "Should not be able to connect after server shutdown"
+    );
+
+    // Verify socket cleanup on Unix
+    #[cfg(unix)]
+    {
+        let socket_path = std::path::Path::new(&config.endpoint_path);
+        assert!(
+            !socket_path.exists(),
+            "Socket file should be cleaned up after shutdown"
+        );
+    }
+}

--- a/sentinel-lib/tests/resilient_client_integration.rs
+++ b/sentinel-lib/tests/resilient_client_integration.rs
@@ -15,7 +15,7 @@
 
 use sentinel_lib::ipc::client::{ConnectionState, ResilientIpcClient};
 use sentinel_lib::ipc::interprocess_transport::InterprocessServer;
-use sentinel_lib::ipc::{Crc32Variant, IpcConfig, TransportType};
+use sentinel_lib::ipc::{IpcConfig, TransportType};
 use sentinel_lib::proto::{DetectionResult, DetectionTask, TaskType};
 use std::time::Duration;
 use tempfile::TempDir;
@@ -33,7 +33,6 @@ fn create_test_config() -> (IpcConfig, TempDir) {
         read_timeout_ms: 5000,
         write_timeout_ms: 5000,
         max_connections: 4,
-        crc32_variant: Crc32Variant::Ieee,
     };
 
     (config, temp_dir)

--- a/sentinel-lib/tests/resilient_client_integration.rs
+++ b/sentinel-lib/tests/resilient_client_integration.rs
@@ -33,6 +33,7 @@ fn create_test_config() -> (IpcConfig, TempDir) {
         read_timeout_ms: 5000,
         write_timeout_ms: 5000,
         max_connections: 4,
+        panic_strategy: sentinel_lib::ipc::PanicStrategy::Unwind,
     };
 
     (config, temp_dir)
@@ -143,7 +144,7 @@ async fn test_automatic_reconnection() {
     let state = client.get_connection_state().await;
     assert_eq!(state, ConnectionState::Connected);
 
-    server.stop();
+    let _result = server.graceful_shutdown().await;
 }
 
 #[tokio::test]
@@ -203,7 +204,7 @@ async fn test_server_error_handling() {
             .contains("Test server error")
     );
 
-    server.stop();
+    let _result = server.graceful_shutdown().await;
 }
 
 #[tokio::test]
@@ -266,7 +267,7 @@ async fn test_concurrent_requests() {
     // At least some requests should succeed
     assert!(successful_requests > 0, "No requests succeeded");
 
-    server.stop();
+    let _result = server.graceful_shutdown().await;
 }
 
 #[tokio::test]
@@ -315,7 +316,7 @@ async fn test_force_reconnection() {
 
     assert!(result2.success);
 
-    server.stop();
+    let _result = server.graceful_shutdown().await;
 }
 
 #[tokio::test]

--- a/sentinelagent/Cargo.toml
+++ b/sentinelagent/Cargo.toml
@@ -23,7 +23,6 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
-crc32fast = { workspace = true }
 futures = { workspace = true }
 
 # IPC communication

--- a/sentinelagent/src/ipc_client.rs
+++ b/sentinelagent/src/ipc_client.rs
@@ -34,7 +34,7 @@ pub struct IpcClientManager {
 impl IpcClientManager {
     /// Create a new IPC client manager with the given configuration
     pub fn new(config: IpcConfig) -> AnyhowResult<Self> {
-        let codec = IpcCodec::new(config.max_frame_bytes, config.crc32_variant.clone());
+        let codec = IpcCodec::new(config.max_frame_bytes);
 
         Ok(Self {
             config,
@@ -325,7 +325,6 @@ pub fn create_default_ipc_config() -> IpcConfig {
         read_timeout_ms: 30000,     // 30 seconds
         write_timeout_ms: 10000,    // 10 seconds
         max_connections: 4,
-        crc32_variant: sentinel_lib::ipc::Crc32Variant::Ieee,
     }
 }
 
@@ -343,7 +342,6 @@ pub fn create_maximum_ipc_config() -> IpcConfig {
         read_timeout_ms: 60000,       // 60 seconds - maximum read timeout
         write_timeout_ms: 30000,      // 30 seconds - maximum write timeout
         max_connections: 16,          // Maximum connections
-        crc32_variant: sentinel_lib::ipc::Crc32Variant::Ieee,
     }
 }
 
@@ -376,7 +374,6 @@ mod tests {
             read_timeout_ms: 5000,
             write_timeout_ms: 5000,
             max_connections: 4,
-            crc32_variant: sentinel_lib::ipc::Crc32Variant::Ieee,
         };
 
         (config, temp_dir)

--- a/sentinelagent/src/ipc_client.rs
+++ b/sentinelagent/src/ipc_client.rs
@@ -325,6 +325,7 @@ pub fn create_default_ipc_config() -> IpcConfig {
         read_timeout_ms: 30000,     // 30 seconds
         write_timeout_ms: 10000,    // 10 seconds
         max_connections: 4,
+        panic_strategy: sentinel_lib::ipc::PanicStrategy::Abort, // Production configuration
     }
 }
 
@@ -342,6 +343,7 @@ pub fn create_maximum_ipc_config() -> IpcConfig {
         read_timeout_ms: 60000,       // 60 seconds - maximum read timeout
         write_timeout_ms: 30000,      // 30 seconds - maximum write timeout
         max_connections: 16,          // Maximum connections
+        panic_strategy: sentinel_lib::ipc::PanicStrategy::Abort, // Production configuration
     }
 }
 
@@ -374,6 +376,7 @@ mod tests {
             read_timeout_ms: 5000,
             write_timeout_ms: 5000,
             max_connections: 4,
+            panic_strategy: sentinel_lib::ipc::PanicStrategy::Unwind,
         };
 
         (config, temp_dir)


### PR DESCRIPTION
This pull request updates the IPC protocol’s checksum implementation from `crc32fast` (CRC32 IEEE) to `crc32c` (CRC32C Castagnoli) for improved reliability and hardware acceleration support. The change is applied across dependencies and the message envelope logic, ensuring consistent checksum calculation and validation. Additionally, related tasks in the specs are marked as completed, reflecting progress in IPC migration and testing.

**Checksum Implementation Update:**
* Replaced the `crc32fast` crate with `crc32c` in `Cargo.toml`, `procmond/Cargo.toml`, and `sentinel-lib/Cargo.toml` to use CRC32C Castagnoli for checksumming. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L42-R42) [[2]](diffhunk://#diff-b897022db62e6650022659fd2f119855d7dae0054e80890ea7fddad8282cffb1L35-R38) [[3]](diffhunk://#diff-6b17530ec962f9ea0124d7137f6156ec70eb366a19c3963ab384f154b95a8c68L46-R46)
* Updated `MessageEnvelope` checksum calculation and validation logic in `procmond/src/ipc/protocol.rs` to use `crc32c::crc32c` instead of `crc32fast::Hasher`. [[1]](diffhunk://#diff-1b0fcf780d8cf6695d12ec1799c4c5f4d6d431f8a3c027306897640959942fbbL52-R52) [[2]](diffhunk://#diff-1b0fcf780d8cf6695d12ec1799c4c5f4d6d431f8a3c027306897640959942fbbL68-R66)
* Removed the `crc32_variant` field from IPC server configuration in `procmond/src/ipc/mod.rs` to align with the new checksum implementation.

**Spec and Task Completion:**
* Marked IPC protocol migration and comprehensive interprocess communication testing as completed in `.kiro/specs/sentineld-core-monitoring/tasks.md`. [[1]](diffhunk://#diff-bdad98fdfc9d5b6b2d78d441651e407e41f09c7dbc2c5932898a6e83ad274246L20-R20) [[2]](diffhunk://#diff-bdad98fdfc9d5b6b2d78d441651e407e41f09c7dbc2c5932898a6e83ad274246L54-R54)